### PR TITLE
Added windows support

### DIFF
--- a/impl/src/derive.rs
+++ b/impl/src/derive.rs
@@ -16,6 +16,7 @@ pub fn expand(input: DeriveInput) -> TokenStream {
     let ident = linkme_ident.expect("attribute linkme_ident");
     let linux_section = linker::linux::section(&ident);
     let macos_section = linker::macos::section(&ident);
+    let windows_section = linker::windows::section(&ident);
 
     TokenStream::from(quote! {
         #[doc(hidden)]
@@ -25,6 +26,7 @@ pub fn expand(input: DeriveInput) -> TokenStream {
                 #[used]
                 #[cfg_attr(target_os = "linux", link_section = #linux_section)]
                 #[cfg_attr(target_os = "macos", link_section = #macos_section)]
+                #[cfg_attr(target_os = "windows", link_section = #windows_section)]
                 $item
             };
         }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit="128"]
 extern crate proc_macro;
 
 mod args;

--- a/impl/src/linker.rs
+++ b/impl/src/linker.rs
@@ -29,3 +29,19 @@ pub mod macos {
         format!("\x01section$end$__DATA$__{}", ident)
     }
 }
+
+pub mod windows {
+    use syn::Ident;
+
+    pub fn section(ident: &Ident) -> String {
+        format!(".linkme_{}$b", ident)
+    }
+
+    pub fn section_start(ident: &Ident) -> String {
+        format!(".linkme_{}$a", ident)
+    }
+
+    pub fn section_stop(ident: &Ident) -> String {
+        format!(".linkme_{}$c", ident)
+    }
+}

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -119,10 +119,20 @@ impl<T> Clone for StaticPtr<T> {
 
 impl<T> DistributedSlice<[T]> {
     #[doc(hidden)]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub const unsafe fn private_new(start: *const T, stop: *const T) -> Self {
         DistributedSlice {
             start: StaticPtr { ptr: start },
             stop: StaticPtr { ptr: stop },
+        }
+    }
+
+    #[doc(hidden)]
+    #[cfg(target_os = "windows")]
+    pub const unsafe fn private_new(start: *const (), stop: *const ()) -> Self {
+        DistributedSlice {
+            start: StaticPtr { ptr: start as *const T },
+            stop: StaticPtr { ptr: stop as *const T},
         }
     }
 


### PR DESCRIPTION
*Works on my machine*...

It uses the fact that segments are sorted by the linker and '$' as a terminator for the segment name to create unique sorted segment names.
`.data$a` becomes the start segment.
`.data$b` is the segment containing the data.
`.data$c` is the end segment.
The `static` entries in the start and end segments are zero-sized and thus can be used as start and end pointers.

I know that #2 and the linked pages mentioned issues with name length and padding, but I haven't encountered that in my testing. Maybe they are old details that are no longer relevant?