### PR TITLE
Add `#[used]` to `LINKME_PLEASE` static.

### DIFF
--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -91,6 +91,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
 
             #[cfg(target_os = "linux")]
             #[link_section = #linux_section]
+            #[used]
             static LINKME_PLEASE: [<#ty as linkme::private::Slice>::Element; 0] = [];
 
             #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]


### PR DESCRIPTION
Hiya, when compiling the tests in `release` mode on Ubuntu 19.04, linking would fail with the following:

* `ld` (`/usr/bin/x86_64-linux-gnu-ld`)

    ```
    ..(redacted).. undefined reference to `__stop_linkme_EMPTY'
    ..(redacted).. undefined reference to `__start_linkme_EMPTY'
    ```

* `lld`


    ```
    ld: error: undefined symbol: __stop_linkme_EMPTY
          >>> referenced by distributed_slice.11cifgtw-cgu.5
          ..(redacted)..
    ld: error: undefined symbol: __start_linkme_EMPTY
          >>> referenced by distributed_slice.11cifgtw-cgu.5
          ..(redacted)..
    ```

Adding the `#[used]` annotation prevents the symbols from being optimized out and is tested to work with both `ld` and `lld`.

I'm using `cargo` defaults -- haven't tweaked optimization settings.
