### PR TITLE
Support target_os = "none"

### DIFF
--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -70,13 +70,13 @@ pub fn expand(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         #(#attrs)*
         #vis static #ident: linkme::DistributedSlice<#ty> = {
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            #[cfg(any(target_os = "none", target_os = "linux", target_os = "macos"))]
             extern "C" {
-                #[cfg_attr(target_os = "linux", link_name = #linux_section_start)]
+                #[cfg_attr(any(target_os = "none", target_os = "linux"), link_name = #linux_section_start)]
                 #[cfg_attr(target_os = "macos", link_name = #macos_section_start)]
                 static LINKME_START: <#ty as linkme::private::Slice>::Element;
 
-                #[cfg_attr(target_os = "linux", link_name = #linux_section_stop)]
+                #[cfg_attr(any(target_os = "none", target_os = "linux"), link_name = #linux_section_stop)]
                 #[cfg_attr(target_os = "macos", link_name = #macos_section_stop)]
                 static LINKME_STOP: <#ty as linkme::private::Slice>::Element;
             }
@@ -89,12 +89,12 @@ pub fn expand(input: TokenStream) -> TokenStream {
             #[link_section = #windows_section_stop]
             static LINKME_STOP: () = ();
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "none", target_os = "linux"))]
             #[link_section = #linux_section]
             #[used]
             static LINKME_PLEASE: [<#ty as linkme::private::Slice>::Element; 0] = [];
 
-            #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+            #[cfg(not(any(target_os = "none", target_os = "linux", target_os = "macos", target_os = "windows")))]
             #unsupported_platform
 
             unsafe {

--- a/impl/src/derive.rs
+++ b/impl/src/derive.rs
@@ -24,7 +24,7 @@ pub fn expand(input: DeriveInput) -> TokenStream {
         macro_rules! #ident {
             ($item:item) => {
                 #[used]
-                #[cfg_attr(target_os = "linux", link_section = #linux_section)]
+                #[cfg_attr(any(target_os = "none", target_os = "linux"), link_section = #linux_section)]
                 #[cfg_attr(target_os = "macos", link_section = #macos_section)]
                 #[cfg_attr(target_os = "windows", link_section = #windows_section)]
                 $item

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -119,7 +119,7 @@ impl<T> Clone for StaticPtr<T> {
 
 impl<T> DistributedSlice<[T]> {
     #[doc(hidden)]
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "none", target_os = "linux", target_os = "macos"))]
     pub const unsafe fn private_new(start: *const T, stop: *const T) -> Self {
         DistributedSlice {
             start: StaticPtr { ptr: start },


### PR DESCRIPTION
Hoping something like this is acceptable? Perhaps a feature flag instead if controversial, but it certainly is useful to enable use of this crate in embedded contexts. The current `target_os = "linux"` support just uses a standard ELF linker feature, as supported by binutils/ld and [llvm-ld](https://reviews.llvm.org/D39548), so should be just as applicable to any embedded targets that rust supports.

Embedded linker scripts however may not support orphan sections out of the box depending on how they're set up; support for them mostly depends on whether [MEMORY sections](
http://sourceware.org/binutils/docs/ld/MEMORY.html) include any attrs that would allow the section to be placed. So for example, modifying the [cortex-m-rt template](
https://github.com/rust-embedded/cortex-m-quickstart/blob/master/memory.x) to use `FLASH (r) :` instead of `FLASH :` is enough to make it work with that ecosystem.

Alternatively, explicit sections can be set up with a supplementary linker script such as:
```ld
SECTIONS {
  linkme_DSLICE : { *(linkme_DSLICE) } > FLASH
}
INSERT BEFORE .rodata
```

And passing `-C link-arg=-Tdslice.x`. Obviously more cumbersome but allows use-cases that are conscious about the final binary layout to use it while still preventing any orphan sections from slipping past.

Alternatives like say the windows approach where you define the sections to be sorted alphabetically can also work but requires a bit more coordination with the linker scripts, which often will not bother to `SORT()` their input sections unless there's some existing reason for it. It would however allow you to modify the linker script in such a way that it can link in arbitrarily named linkme slices while not resorting to reliance on / enabling orphan sections:
```ld
SECTIONS {
  .rodata.linkme : { *(SORT(linkme_*)) } > FLASH
}
INSERT BEFORE .rodata
```