### PR TITLE
Reexport generated macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ rust:
 
 matrix:
   include:
-    - rust: 1.31.0
-      script: cargo test --tests
     - rust: 1.32.0
     - rust: nightly
       os: osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ documentation = "https://docs.rs/linkme"
 readme = "README.md"
 edition = "2018"
 
+[[test]]
+name = "module_2015"
+edition = "2015"
+
 [dependencies]
 linkme-impl = { version = "=0.1.5", path = "impl" }
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ here.
 linkme = "0.1"
 ```
 
-*Supports rustc 1.31+*
+*Supports rustc 1.32+*
 
 <br>
 

--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -64,8 +64,8 @@ pub fn expand(input: TokenStream) -> TokenStream {
 
     let call_site = Span::call_site();
     let ident_str = ident.to_string();
-    let link_section_macro_dummy = format!("_linkme_macro_{}", ident);
-    let link_section_macro_dummy = Ident::new(&link_section_macro_dummy, call_site);
+    let link_section_macro_dummy_str = format!("_linkme_macro_{}", ident);
+    let link_section_macro_dummy = Ident::new(&link_section_macro_dummy_str, call_site);
 
     TokenStream::from(quote! {
         #(#attrs)*
@@ -102,9 +102,14 @@ pub fn expand(input: TokenStream) -> TokenStream {
             }
         };
 
-        #[derive(linkme::link_section_macro)]
+        #[macro_use]
+        mod #link_section_macro_dummy {
+            #[derive(linkme::link_section_macro)]
+            #[linkme_ident = #ident_str]
+            #[linkme_macro = #link_section_macro_dummy_str]
+            struct __linkme_dummy;
+        }
         #[doc(hidden)]
-        #[linkme_ident = #ident_str]
-        struct #link_section_macro_dummy;
+        #vis use #link_section_macro_dummy as #ident;
     })
 }

--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -66,6 +66,8 @@ pub fn expand(input: TokenStream) -> TokenStream {
     let ident_str = ident.to_string();
     let link_section_macro_dummy_str = format!("_linkme_macro_{}", ident);
     let link_section_macro_dummy = Ident::new(&link_section_macro_dummy_str, call_site);
+    let link_section_mod_dummy_str = format!("_linkme_module_{}", ident);
+    let link_section_mod_dummy = Ident::new(&link_section_mod_dummy_str, call_site);
 
     TokenStream::from(quote! {
         #(#attrs)*
@@ -103,12 +105,13 @@ pub fn expand(input: TokenStream) -> TokenStream {
         };
 
         #[macro_use]
-        mod #link_section_macro_dummy {
+        mod #link_section_mod_dummy {
             #[derive(linkme::link_section_macro)]
             #[linkme_ident = #ident_str]
             #[linkme_macro = #link_section_macro_dummy_str]
-            struct __linkme_dummy;
+            struct _linkme_dummy;
         }
+
         #[doc(hidden)]
         #vis use #link_section_macro_dummy as #ident;
     })

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -24,7 +24,7 @@ pub fn distributed_slice(args: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 #[doc(hidden)]
-#[proc_macro_derive(link_section_macro, attributes(linkme_ident))]
+#[proc_macro_derive(link_section_macro, attributes(linkme_ident, linkme_macro))]
 pub fn link_section_macro(input: TokenStream) -> TokenStream {
     let expanded = derive::expand(parse_macro_input!(input));
     TokenStream::from(expanded)

--- a/tests/module.rs
+++ b/tests/module.rs
@@ -1,0 +1,18 @@
+mod declaration {
+    use linkme::distributed_slice;
+
+    #[distributed_slice]
+    pub static SLICE: [i32] = [..];
+
+    #[test]
+    fn test_mod_slice() {
+        assert!(!SLICE.is_empty());
+    }
+}
+
+mod usage {
+    use linkme::distributed_slice;
+
+    #[distributed_slice(super::declaration::SLICE)]
+    pub static N: i32 = 9;
+}

--- a/tests/module_2015.rs
+++ b/tests/module_2015.rs
@@ -1,0 +1,3 @@
+extern crate linkme;
+
+include!("module.rs");


### PR DESCRIPTION
Fixes #18 by allowing definition of slices from non-crate-root contexts such as a module to work as one would expect. Feels like a kind of hacky solution, but I'm familiar enough with rust's macro path resolution rules to know of a better one. I included a 2015 edition test just to be sure that it doesn't break anything (and I'm somewhat surprised that it works?).