### PR TITLE
!Copy test shouldn't use a ZST

### DIFF
--- a/tests/distributed_slice.rs
+++ b/tests/distributed_slice.rs
@@ -34,11 +34,13 @@ fn test_empty() {
 
 #[test]
 fn test_non_copy() {
-    struct NonCopy;
+    struct NonCopy(i32);
 
     #[distributed_slice]
     static NONCOPY: [NonCopy] = [..];
 
     #[distributed_slice(NONCOPY)]
-    static ELEMENT: NonCopy = NonCopy;
+    static ELEMENT: NonCopy = NonCopy(9);
+
+    assert!(!NONCOPY.is_empty());
 }


### PR DESCRIPTION
This is a bit pedantic but [the crate currently doesn't really support ZSTs the way one might expect it to](https://github.com/dtolnay/linkme/blob/9b75cdad91e5ab15f5faf7a461b1a1f996640171/src/distributed_slice.rs#L187) so it seems a bit silly to have a test make use of them. Though on the flip side maybe there should be a test that explicitly tests that ZSTs "work" as currently implemented (check that they're are always empty). IMO it may be worth just making them fail to typecheck/compile for now if the supported rustc versions are fine with const `size_of`? or just fixing ZST support but eh.