### PR TITLE
add option to specify the path to linkme crate

### DIFF
--- a/impl/src/common.rs
+++ b/impl/src/common.rs
@@ -1,0 +1,46 @@
+use syn::parse::{Error, ParseStream, Result};
+use syn::Lit::*;
+use syn::Meta::*;
+use syn::{Attribute, Path};
+
+pub(crate) fn extract_linkme_path(attrs: &mut Vec<Attribute>) -> Result<Path> {
+    let mut linkme_path = None;
+
+    let mut errors: Option<Error> = None;
+    attrs.retain(|attr| {
+        if attr.path.is_ident("linkme") {
+            let res = attr.parse_args_with(|input: ParseStream| -> Result<Path> {
+                match input.parse()? {
+                    NameValue(m) if m.path.is_ident("crate") => match m.lit {
+                        Str(lit) => lit.parse_with(Path::parse_mod_style),
+                        lit => Err(Error::new_spanned(&lit, "expected a string literal")),
+                    },
+                    m => Err(Error::new_spanned(
+                        &m,
+                        "expected `#[linkme(crate = \"path::to::linkme\"]`",
+                    )),
+                }
+            });
+
+            match res {
+                Ok(path) => {
+                    linkme_path = Some(path);
+                }
+                Err(err) => match errors {
+                    Some(ref mut errors) => errors.combine(err),
+                    None => errors = Some(err),
+                },
+            }
+
+            return false;
+        }
+
+        true
+    });
+
+    if let Some(errors) = errors {
+        return Err(errors);
+    }
+
+    Ok(linkme_path.unwrap_or_else(|| syn::parse_quote!(::linkme)))
+}

--- a/impl/src/element.rs
+++ b/impl/src/element.rs
@@ -1,8 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
+use std::iter::FromIterator;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::{Attribute, Ident, Path, Token, Type, Visibility};
-use std::iter::FromIterator;
+
+use crate::common::extract_linkme_path;
 
 pub struct Element {
     attrs: Vec<Attribute>,
@@ -37,21 +39,26 @@ impl Parse for Element {
 }
 
 pub fn expand(path: Path, input: Element) -> TokenStream {
-    let attrs = input.attrs;
+    let mut attrs = input.attrs;
     let vis = input.vis;
     let ident = input.ident;
     let ty = input.ty;
     let expr = input.expr;
 
+    let linkme_path = match extract_linkme_path(&mut attrs) {
+        Ok(path) => path,
+        Err(err) => return err.to_compile_error(),
+    };
+
     let span = quote!(#ty).into_iter().next().unwrap().span();
-    let uninit = quote_spanned!(span=> linkme::private::value::<#ty>());
+    let uninit = quote_spanned!(span=> #linkme_path::private::value::<#ty>());
 
     TokenStream::from(quote! {
         #path ! {
             #(#attrs)*
             #vis static #ident : #ty = {
-                unsafe fn __typecheck(_: linkme::private::Void) {
-                    linkme::DistributedSlice::private_typecheck(#path, #uninit)
+                unsafe fn __typecheck(_: #linkme_path::private::Void) {
+                    #linkme_path::DistributedSlice::private_typecheck(#path, #uninit)
                 }
 
                 #expr

--- a/impl/src/element.rs
+++ b/impl/src/element.rs
@@ -51,14 +51,16 @@ pub fn expand(path: Path, input: Element) -> TokenStream {
     };
 
     let span = quote!(#ty).into_iter().next().unwrap().span();
-    let uninit = quote_spanned!(span=> #linkme_path::private::value::<#ty>());
+    let uninit = quote_spanned!(span=> __linkme::private::value::<#ty>());
 
     TokenStream::from(quote! {
         #path ! {
             #(#attrs)*
             #vis static #ident : #ty = {
-                unsafe fn __typecheck(_: #linkme_path::private::Void) {
-                    #linkme_path::DistributedSlice::private_typecheck(#path, #uninit)
+                use #linkme_path as __linkme;
+
+                unsafe fn __typecheck(_: __linkme::private::Void) {
+                    __linkme::DistributedSlice::private_typecheck(#path, #uninit)
                 }
 
                 #expr

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate proc_macro;
 
 mod args;
+mod common;
 mod declaration;
 mod derive;
 mod element;

--- a/tests/custom_linkme_path.rs
+++ b/tests/custom_linkme_path.rs
@@ -1,0 +1,22 @@
+use linkme as link_me;
+
+mod declaration {
+    use crate::link_me::distributed_slice;
+
+    #[distributed_slice]
+    #[linkme(crate = "crate::link_me")]
+    pub static SLICE: [i32] = [..];
+
+    #[test]
+    fn test_mod_slice() {
+        assert!(!SLICE.is_empty());
+    }
+}
+
+mod usage {
+    use crate::link_me::distributed_slice;
+
+    #[distributed_slice(super::declaration::SLICE)]
+    #[linkme(crate = "crate::link_me")]
+    pub static N: i32 = 9;
+}

--- a/tests/custom_linkme_path.rs
+++ b/tests/custom_linkme_path.rs
@@ -17,6 +17,6 @@ mod usage {
     use crate::link_me::distributed_slice;
 
     #[distributed_slice(super::declaration::SLICE)]
-    #[linkme(crate = "crate::link_me")]
+    #[linkme(crate(crate::link_me))]
     pub static N: i32 = 9;
 }


### PR DESCRIPTION
This patch introduces an attribute to specify the path to `linkme` crate used in the generated code. It is done by filtering the corresponding elements from the parsed attribute list and it is applied both to the declarative and element side.

The motivation for adding this attribute is to support re-exporting `linkme` itself as well as [`#[serde(crate = "...")]`](https://serde.rs/container-attrs.html#crate) in `serde`, and the syntax follows the original.