### PR TITLE
accept function items as distributed element

### DIFF
--- a/impl/src/element.rs
+++ b/impl/src/element.rs
@@ -1,39 +1,56 @@
 use crate::attr;
 use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned};
-use std::iter::FromIterator;
-use syn::parse::{Parse, ParseStream, Result};
-use syn::{Attribute, Ident, Path, Token, Type, Visibility};
+use quote::{format_ident, quote, quote_spanned};
+use syn::parse::{Error, Parse, ParseStream, Result};
+use syn::spanned::Spanned;
+use syn::{
+    Attribute, BareFnArg, BoundLifetimes, Expr, ExprPath, FnArg, GenericParam, Ident, Item, ItemFn,
+    Pat, PatType, Path, Type, TypeBareFn, Visibility,
+};
 
 pub struct Element {
     attrs: Vec<Attribute>,
     vis: Visibility,
     ident: Ident,
     ty: Type,
-    expr: TokenStream,
+    expr: Expr,
+    orig_item: Option<Item>,
 }
 
 impl Parse for Element {
     fn parse(input: ParseStream) -> Result<Self> {
-        let attrs = input.call(Attribute::parse_outer)?;
-        let vis: Visibility = input.parse()?;
-        input.parse::<Token![static]>()?;
-        let ident: Ident = input.parse()?;
-        input.parse::<Token![:]>()?;
-        let ty: Type = input.parse()?;
-        input.parse::<Token![=]>()?;
-        let mut expr_semi = Vec::from_iter(input.parse::<TokenStream>()?);
-        if let Some(tail) = expr_semi.pop() {
-            syn::parse2::<Token![;]>(TokenStream::from(tail))?;
+        match input.parse()? {
+            Item::Static(item) => Ok(Element {
+                attrs: item.attrs,
+                vis: item.vis,
+                ident: item.ident,
+                ty: *item.ty,
+                expr: *item.expr,
+                orig_item: None,
+            }),
+            Item::Fn(item) => {
+                let ident = format_ident!("_LINKME_ELEMENT_{}", item.sig.ident);
+                let ty = extract_bare_fn_type(&item).map(Type::BareFn)?;
+                let expr = Expr::Path(ExprPath {
+                    attrs: vec![],
+                    qself: None,
+                    path: item.sig.ident.clone().into(),
+                });
+
+                Ok(Element {
+                    attrs: vec![syn::parse_quote!(#[allow(non_upper_case_globals)])],
+                    vis: Visibility::Inherited,
+                    ident,
+                    ty,
+                    expr,
+                    orig_item: Some(Item::Fn(item)),
+                })
+            }
+            item => Err(Error::new_spanned(
+                &item,
+                "distributed element must be either static or function item",
+            )),
         }
-        let expr = TokenStream::from_iter(expr_semi);
-        Ok(Element {
-            attrs,
-            vis,
-            ident,
-            ty,
-            expr,
-        })
     }
 }
 
@@ -43,13 +60,17 @@ pub fn expand(path: Path, input: Element) -> TokenStream {
     let ident = input.ident;
     let ty = input.ty;
     let expr = input.expr;
+    let orig_item = input.orig_item;
 
     let linkme_path = match attr::linkme_path(&mut attrs) {
         Ok(path) => path,
         Err(err) => return err.to_compile_error(),
     };
 
-    let span = quote!(#ty).into_iter().next().unwrap().span();
+    let span = match orig_item {
+        Some(ref item) => item.span(),
+        None => quote!(#ty).into_iter().next().unwrap().span(),
+    };
     let new = quote_spanned!(span=> __new);
     let uninit = quote_spanned!(span=> __new());
 
@@ -65,5 +86,80 @@ pub fn expand(path: Path, input: Element) -> TokenStream {
                 #expr
             };
         }
+
+        #orig_item
+    })
+}
+
+fn extract_bare_fn_type(item: &ItemFn) -> Result<TypeBareFn> {
+    let sig = &item.sig;
+
+    if let Some(ref where_clause) = sig.generics.where_clause {
+        for pred in &where_clause.predicates {
+            if let syn::WherePredicate::Lifetime(lt) = pred {
+                return Err(Error::new_spanned(
+                    lt,
+                    "lifetime bounds cannot be used in this context",
+                ));
+            }
+        }
+    }
+
+    let mut lifetimes: Option<BoundLifetimes> = None;
+    for param in &sig.generics.params {
+        match param {
+            GenericParam::Lifetime(lifetime) => {
+                let lifetimes = lifetimes.get_or_insert_with(Default::default);
+                lifetimes.lifetimes.push(lifetime.clone());
+            }
+            param => {
+                return Err(Error::new_spanned(
+                    param,
+                    "distributed element cannot accept generic parameters",
+                ));
+            }
+        }
+    }
+
+    let inputs = sig
+        .inputs
+        .iter()
+        .map(|input| {
+            let error =
+                || Error::new_spanned(item, "methods cannot be specified as distributed element");
+
+            match input {
+                FnArg::Receiver(..) => Err(error()),
+                // Note: the guard below is equivalent to
+                //
+                //     matches!(&**pat, Pat::Ident(pat) if pat.ident == "self")
+                //
+                // from 1.42.0.
+                FnArg::Typed(PatType { ref pat, .. })
+                    if match &**pat {
+                        Pat::Ident(pat) if pat.ident == "self" => true,
+                        _ => false,
+                    } =>
+                {
+                    Err(error())
+                }
+                FnArg::Typed(ref pat) => Ok(BareFnArg {
+                    attrs: pat.attrs.clone(),
+                    name: None,
+                    ty: (*pat.ty).clone(),
+                }),
+            }
+        })
+        .collect::<Result<_>>()?;
+
+    Ok(TypeBareFn {
+        lifetimes,
+        unsafety: sig.unsafety.clone(),
+        abi: sig.abi.clone(),
+        fn_token: sig.fn_token.clone(),
+        paren_token: sig.paren_token.clone(),
+        inputs,
+        variadic: sig.variadic.clone(),
+        output: sig.output.clone(),
     })
 }

--- a/tests/fn_element.rs
+++ b/tests/fn_element.rs
@@ -1,0 +1,28 @@
+use linkme::distributed_slice;
+
+#[distributed_slice]
+pub static SLICE1: [fn()] = [..];
+
+#[distributed_slice(SLICE1)]
+fn foo() {}
+
+#[distributed_slice]
+pub static SLICE2: [for<'a, 'b> fn(&'a &'b ())] = [..];
+
+#[distributed_slice(SLICE2)]
+fn bar<'a, 'b>(_: &'a &'b ()) {}
+
+#[distributed_slice]
+pub static SLICE3: [unsafe extern "C" fn() -> i32] = [..];
+
+#[distributed_slice(SLICE3)]
+unsafe extern "C" fn baz() -> i32 {
+    42
+}
+
+#[test]
+fn test_slices() {
+    assert!(!SLICE1.is_empty());
+    assert!(!SLICE2.is_empty());
+    assert!(!SLICE3.is_empty());
+}

--- a/tests/ui/generic_fn.rs
+++ b/tests/ui/generic_fn.rs
@@ -1,0 +1,12 @@
+use linkme::distributed_slice;
+
+#[distributed_slice]
+pub static SLICES: [fn()] = [..];
+
+#[distributed_slice(SLICES)]
+fn type_param<T>() {}
+
+#[distributed_slice(SLICES)]
+fn const_param<const N: usize>() {}
+
+fn main() {}

--- a/tests/ui/generic_fn.stderr
+++ b/tests/ui/generic_fn.stderr
@@ -1,0 +1,11 @@
+error: distributed element cannot accept generic parameters
+ --> $DIR/generic_fn.rs:7:15
+  |
+7 | fn type_param<T>() {}
+  |               ^
+
+error: distributed element cannot accept generic parameters
+  --> $DIR/generic_fn.rs:10:16
+   |
+10 | fn const_param<const N: usize>() {}
+   |                ^^^^^^^^^^^^^^

--- a/tests/ui/mismatched_types.rs
+++ b/tests/ui/mismatched_types.rs
@@ -8,4 +8,7 @@ pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
 #[distributed_slice(BENCHMARKS)]
 static BENCH_WTF: usize = 999;
 
+#[distributed_slice(BENCHMARKS)]
+fn wrong_bench_fn<'a>(_: &'a mut ()) {}
+
 fn main() {}

--- a/tests/ui/mismatched_types.stderr
+++ b/tests/ui/mismatched_types.stderr
@@ -6,3 +6,12 @@ error[E0308]: mismatched types
   |
   = note: expected fn pointer `for<'r> fn(&'r mut Bencher)`
                    found type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched_types.rs:12:1
+   |
+12 | fn wrong_bench_fn<'a>(_: &'a mut ()) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Bencher`, found `()`
+   |
+   = note: expected fn pointer `for<'r> fn(&'r mut Bencher)`
+              found fn pointer `for<'a> fn(&'a mut ())`

--- a/tests/ui/unsupported_item.rs
+++ b/tests/ui/unsupported_item.rs
@@ -1,0 +1,9 @@
+use linkme::distributed_slice;
+
+#[distributed_slice]
+pub static SLICE: [&'static str] = [..];
+
+#[distributed_slice(SLICE)]
+extern crate std as _std;
+
+fn main() {}

--- a/tests/ui/unsupported_item.stderr
+++ b/tests/ui/unsupported_item.stderr
@@ -1,0 +1,5 @@
+error: distributed element must be either static or function item
+ --> $DIR/unsupported_item.rs:7:1
+  |
+7 | extern crate std as _std;
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
It adds free functions as target items that can be applied to the element side of `#[distributed_slice]`. This works by generating an (implicit) static variable whose value is the pointer to the specified function item, as mentioned in the comment at #24.



fixes #24.