### PR TITLE
Add `DistributedSlice::contains_ptr`

### DIFF
--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -223,6 +223,11 @@ impl<T> DistributedSlice<[T]> {
         let len = byte_offset / stride;
         unsafe { slice::from_raw_parts(start, len) }
     }
+
+    /// Returns `true` if `ptr` references a value within the distributed slice.
+    pub fn contains_ptr(this: Self, ptr: *const T) -> bool {
+        this.start.ptr <= ptr && this.stop.ptr > ptr
+    }
 }
 
 impl<T> Copy for DistributedSlice<[T]> {}


### PR DESCRIPTION
Implemented as a type-level function to prevent accidentally calling any future slice methods. This is a convention used by smart pointers.

Alternative: users manually call [`contains`](https://doc.rust-lang.org/stable/std/ops/struct.Range.html#method.contains) on the result of `as_ptr_range` (#33).