### PR TITLE
Add `DistributedSlice::as_ptr_range`

### DIFF
--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -1,5 +1,5 @@
 use core::mem;
-use core::ops::Deref;
+use core::ops::{Deref, Range};
 use core::slice;
 
 use crate::private::Slice;
@@ -222,6 +222,14 @@ impl<T> DistributedSlice<[T]> {
         let byte_offset = stop as usize - start as usize;
         let len = byte_offset / stride;
         unsafe { slice::from_raw_parts(start, len) }
+    }
+
+    /// Returns the distributed slice as a range of pointers.
+    pub fn as_ptr_range(this: Self) -> Range<*const T> {
+        Range {
+            start: this.start.ptr,
+            end: this.stop.ptr,
+        }
     }
 }
 


### PR DESCRIPTION
Implemented as a type-level function to prevent accidentally calling `slice::as_ptr_range`. This is a convention used by smart pointers.