### PR TITLE
fix target_os = "none" test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,3 @@ jobs:
           sudo apt-get install -y qemu-system-arm
       - run: cargo run --release
         working-directory: tests/cortex
-        # https://github.com/dtolnay/linkme/issues/23
-        continue-on-error: true

--- a/tests/cortex/Cargo.toml
+++ b/tests/cortex/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 cortex-m = "0.6"
-cortex-m-rt = "0.6"
+cortex-m-rt = { git = "https://github.com/rust-embedded/cortex-m-rt" }
 cortex-m-semihosting = "0.3"
 linkme = { path = "../.." }
 panic-semihosting = { version = "0.5", features = ["exit"] }

--- a/tests/cortex/memory.x
+++ b/tests/cortex/memory.x
@@ -8,4 +8,4 @@ SECTIONS {
   linkme_SHENANIGANS : { *(linkme_SHENANIGANS) } > FLASH
   linkme_EMPTY : { *(linkme_EMPTY) } > FLASH
 }
-INSERT BEFORE .rodata
+INSERT AFTER .rodata


### PR DESCRIPTION
`tests/coretex` currently fails with overlapping section linker errors.

This can be fixed by:

1. insert the linkme section AFTER .rodata, not BEFORE
2. bump cortex-m-rt. current master includes [support](https://github.com/rust-embedded/cortex-m-rt/pull/287) for 1.

Unfortunately the necessary fix to cortex-m-rt has not been released (to crates.io), so I'm creating this PR as a draft.

Fixes #23.