### PR TITLE
Add illumos support

### DIFF
--- a/impl/src/derive.rs
+++ b/impl/src/derive.rs
@@ -50,6 +50,8 @@ impl Parse for Enum {
 pub fn expand(input: Enum) -> TokenStream {
     let ident = input.linkme_ident;
     let ident_macro = input.linkme_macro;
+
+    let illumos_section = linker::illumos::section(&ident);
     let linux_section = linker::linux::section(&ident);
     let macos_section = linker::macos::section(&ident);
     let windows_section = linker::windows::section(&ident);
@@ -64,6 +66,7 @@ pub fn expand(input: Enum) -> TokenStream {
                 $item:item
             ) => {
                 $macro ! {
+                    #![linkme_illumos_section = concat!(#illumos_section, $key)]
                     #![linkme_linux_section = concat!(#linux_section, $key)]
                     #![linkme_macos_section = concat!(#macos_section, $key)]
                     #![linkme_windows_section = concat!(#windows_section, $key)]
@@ -71,6 +74,7 @@ pub fn expand(input: Enum) -> TokenStream {
                 }
             };
             (
+                #![linkme_illumos_section = $illumos_section:expr]
                 #![linkme_linux_section = $linux_section:expr]
                 #![linkme_macos_section = $macos_section:expr]
                 #![linkme_windows_section = $windows_section:expr]
@@ -78,6 +82,7 @@ pub fn expand(input: Enum) -> TokenStream {
             ) => {
                 #[used]
                 #[cfg_attr(any(target_os = "none", target_os = "linux"), link_section = $linux_section)]
+                #[cfg_attr(target_os = "illumos", link_section = $illumos_section)]
                 #[cfg_attr(target_os = "macos", link_section = $macos_section)]
                 #[cfg_attr(target_os = "windows", link_section = $windows_section)]
                 $item
@@ -85,6 +90,7 @@ pub fn expand(input: Enum) -> TokenStream {
             ($item:item) => {
                 #[used]
                 #[cfg_attr(any(target_os = "none", target_os = "linux"), link_section = #linux_section)]
+                #[cfg_attr(target_os = "illumos", link_section = #illumos_section)]
                 #[cfg_attr(target_os = "macos", link_section = #macos_section)]
                 #[cfg_attr(target_os = "windows", link_section = #windows_section)]
                 $item

--- a/impl/src/linker.rs
+++ b/impl/src/linker.rs
@@ -1,3 +1,19 @@
+pub mod illumos {
+    use syn::Ident;
+
+    pub fn section(ident: &Ident) -> String {
+        format!("set_linkme_{}", ident)
+    }
+
+    pub fn section_start(ident: &Ident) -> String {
+        format!("__start_set_linkme_{}", ident)
+    }
+
+    pub fn section_stop(ident: &Ident) -> String {
+        format!("__stop_set_linkme_{}", ident)
+    }
+}
+
 pub mod linux {
     use syn::Ident;
 

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -145,7 +145,7 @@ impl<T> Clone for StaticPtr<T> {
 
 impl<T> DistributedSlice<[T]> {
     #[doc(hidden)]
-    #[cfg(any(target_os = "none", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "none", target_os = "illumos", target_os = "linux", target_os = "macos"))]
     pub const unsafe fn private_new(start: *const T, stop: *const T) -> Self {
         DistributedSlice {
             start: StaticPtr { ptr: start },


### PR DESCRIPTION
The section and symbol names have been chosen to match up with the linker set naming provided by `sys/linker_set.h` in [illumos-gate](https://github.com/illumos/illumos-gate/).

I was not sure what you would prefer for ordering and style on the new portions, considering how the platform list may grow in the future.  Please let me know if you have thoughts there, and I can tweak it to match.