### PR TITLE
Bugfix for #[linkme] attribute when also using function element shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ fn bench_deserialize(b: &mut Bencher) {
     /* ... */
 }
 ```
-###Renaming and re-exporting
+### Renaming and re-exporting
 When renaming or re-exporting the linkme library, the code generated in the macros will
 still reference `::linkme` instead of the new name, requiring projects referencing your
 code to also depend on linkme directly. T avoid that you can use the `#[linkme]` attribute

--- a/README.md
+++ b/README.md
@@ -132,6 +132,23 @@ fn bench_deserialize(b: &mut Bencher) {
     /* ... */
 }
 ```
+###Renaming and re-exporting
+When renaming or re-exporting the linkme library, the code generated in the macros will
+still reference `::linkme` instead of the new name, requiring projects referencing your
+code to also depend on linkme directly. T avoid that you can use the `#[linkme]` attribute
+to tell linkme to generate code referencing your re-export. 
+
+```rust
+#[my_crate::linkme::distributed_slice]
+#[linkme(crate=my_crate::linkme)] 
+pub static BENCHMARKS: [i32] = [..];
+```
+Due to the way Rust macro expansion works there is no global setting for this, the
+`#[linkme]` attribute must be repeated on every distributed slice element and on the
+declaration.<br>
+Also, note that the `#[linkme]` attribute itself does not have a path. This is because it isn't 
+expanded as macro but consumed by the expansion of the `#[distributed_slice]` macro. 
+Prefixing it with a path will break your build.   
 
 <br>
 

--- a/tests/custom_linkme_path_with_function.rs
+++ b/tests/custom_linkme_path_with_function.rs
@@ -1,0 +1,22 @@
+use linkme as link_me;
+
+mod declaration {
+    use crate::link_me::distributed_slice;
+
+    #[distributed_slice]
+    #[linkme(crate = crate::link_me)]
+    pub static SLICE: [fn()] = [..];
+
+    #[test]
+    fn test_mod_slice() {
+        assert!(!SLICE.is_empty());
+    }
+}
+
+mod usage {
+    use crate::link_me::distributed_slice;
+
+    #[distributed_slice(super::declaration::SLICE)]
+    #[linkme(crate = crate::link_me)]
+    fn test_me(){}
+}


### PR DESCRIPTION
When using function element shorthand (attribute directly on the function) together with the #[linkme] attribute, the attribute wasn't consumed and left for the compiler to try and expand as a macro, which failed. To fix, the attribute is now consumed from the function and passed on to code generation for the static variable referencing the function. 
Also included is a test case for that scenario and documentation how to use the #[linkme] attribute.

Thanks for creating this library, it's incredibly helpful.