### PR TITLE
Shorten symbol names for Mach-O by hashing

### DIFF
--- a/impl/src/hash.rs
+++ b/impl/src/hash.rs
@@ -1,0 +1,42 @@
+use std::collections::hash_map;
+use std::fmt::{self, Display, Write};
+use std::hash::{Hash, Hasher};
+use syn::Ident;
+
+// 8-character symbol hash consisting of a-zA-Z0-9. We use 8 character because
+// Mach-O section specifiers are restricted to at most 16 characters (see
+// https://github.com/dtolnay/linkme/issues/35) and we leave room for a
+// linkme-specific prefix.
+pub(crate) struct Symbol(u64);
+
+pub(crate) fn hash(ident: &Ident) -> Symbol {
+    let mut hasher = hash_map::DefaultHasher::new();
+    ident.hash(&mut hasher);
+    Symbol(hasher.finish())
+}
+
+impl Display for Symbol {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        // log(62^8)/log(2) is 47.6 so we have enough bits in the 64-bit
+        // standard library hash to produce a good distribution over 8 digits
+        // from a 62-character alphabet.
+        let mut remainder = self.0;
+        for _ in 0..8 {
+            let digit = (remainder % 62) as u8;
+            remainder /= 62;
+            formatter.write_char(match digit {
+                0..=25 => b'a' + digit,
+                26..=51 => b'A' + digit - 26,
+                52..=61 => b'0' + digit - 52,
+                _ => unreachable!(),
+            } as char)?;
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn test_hash() {
+    let ident = Ident::new("EXAMPLE", proc_macro2::Span::call_site());
+    assert_eq!(hash(&ident).to_string(), "0GPSzIoo");
+}

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::needless_pass_by_value,
+    clippy::too_many_lines
+)]
 
 extern crate proc_macro;
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -7,12 +7,13 @@ mod attr;
 mod declaration;
 mod derive;
 mod element;
+mod hash;
 mod linker;
 
+use crate::args::Args;
+use crate::hash::hash;
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
-
-use crate::args::Args;
 
 #[proc_macro_attribute]
 pub fn distributed_slice(args: TokenStream, input: TokenStream) -> TokenStream {

--- a/impl/src/linker.rs
+++ b/impl/src/linker.rs
@@ -18,15 +18,15 @@ pub mod macos {
     use syn::Ident;
 
     pub fn section(ident: &Ident) -> String {
-        format!("__DATA,__{}", ident)
+        format!("__DATA,__linkme{}", crate::hash(ident))
     }
 
     pub fn section_start(ident: &Ident) -> String {
-        format!("\x01section$start$__DATA$__{}", ident)
+        format!("\x01section$start$__DATA$__linkme{}", crate::hash(ident))
     }
 
     pub fn section_stop(ident: &Ident) -> String {
-        format!("\x01section$end$__DATA$__{}", ident)
+        format!("\x01section$end$__DATA$__linkme{}", crate::hash(ident))
     }
 }
 


### PR DESCRIPTION
Fixes #35.