### PR TITLE
Try `__libc_` section prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
           sudo apt-get install -y qemu-system-arm
       - run: cargo run --release
         working-directory: tests/cortex
-        # https://github.com/dtolnay/linkme/issues/40
-        continue-on-error: true
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,10 @@ jobs:
           toolchain: ${{matrix.rust}}
       - run: cargo check --manifest-path tests/crate/Cargo.toml
       - run: cargo test
-        # macos: https://github.com/dtolnay/linkme/issues/41
-        # windows-gnu: https://github.com/dtolnay/linkme/issues/25
-        continue-on-error: ${{matrix.os == 'macos' || matrix.rust == 'nightly-x86_64-pc-windows-gnu'}}
+        # https://github.com/dtolnay/linkme/issues/25
+        continue-on-error: ${{matrix.rust == 'nightly-x86_64-pc-windows-gnu'}}
       - run: cargo test --release
-        continue-on-error: ${{matrix.os == 'macos' || matrix.rust == 'nightly-x86_64-pc-windows-gnu'}}
+        continue-on-error: ${{matrix.rust == 'nightly-x86_64-pc-windows-gnu'}}
 
   msrv:
     name: Rust 1.31.0

--- a/impl/src/linker.rs
+++ b/impl/src/linker.rs
@@ -2,31 +2,33 @@ pub mod linux {
     use syn::Ident;
 
     pub fn section(ident: &Ident) -> String {
-        format!("linkme_{}", ident)
+        format!("__libc_{}", ident)
     }
 
     pub fn section_start(ident: &Ident) -> String {
-        format!("__start_linkme_{}", ident)
+        format!("__start___libc_{}", ident)
     }
 
     pub fn section_stop(ident: &Ident) -> String {
-        format!("__stop_linkme_{}", ident)
+        format!("__stop___libc_{}", ident)
     }
 }
 
 pub mod macos {
     use syn::Ident;
 
+    // __libc_ prefix: see https://github.com/dtolnay/linkme/issues/41. This
+    // makes recent versions of lld recognize the symbol as retained.
     pub fn section(ident: &Ident) -> String {
-        format!("__DATA,__linkme{}", crate::hash(ident))
+        format!("__DATA,__libc_{}", crate::hash(ident))
     }
 
     pub fn section_start(ident: &Ident) -> String {
-        format!("\x01section$start$__DATA$__linkme{}", crate::hash(ident))
+        format!("\x01section$start$__DATA$__libc_{}", crate::hash(ident))
     }
 
     pub fn section_stop(ident: &Ident) -> String {
-        format!("\x01section$end$__DATA$__linkme{}", crate::hash(ident))
+        format!("\x01section$end$__DATA$__libc_{}", crate::hash(ident))
     }
 }
 


### PR DESCRIPTION
Per https://github.com/dtolnay/linkme/issues/41#issuecomment-927351657. Recent versions of lld recognize section names with a `__libc_` prefix as being retained even without rustc support for `llvm.used`.

Relevant to #41 and #40. Sadly as far as I can tell I don't think this fully fixes either one.