### PR TITLE
Fix missing macOS slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,10 @@ jobs:
           toolchain: ${{matrix.rust}}
       - run: cargo check --manifest-path tests/crate/Cargo.toml
       - run: cargo test
-        # macos: https://github.com/dtolnay/linkme/issues/41
         # windows-gnu: https://github.com/dtolnay/linkme/issues/25
-        continue-on-error: ${{matrix.os == 'macos' || matrix.rust == 'nightly-x86_64-pc-windows-gnu'}}
+        continue-on-error: ${{matrix.rust == 'nightly-x86_64-pc-windows-gnu'}}
       - run: cargo test --release
-        continue-on-error: ${{matrix.os == 'macos' || matrix.rust == 'nightly-x86_64-pc-windows-gnu'}}
+        continue-on-error: ${{matrix.rust == 'nightly-x86_64-pc-windows-gnu'}}
 
   msrv:
     name: Rust 1.31.0

--- a/impl/src/linker.rs
+++ b/impl/src/linker.rs
@@ -34,7 +34,7 @@ pub mod macos {
     use syn::Ident;
 
     pub fn section(ident: &Ident) -> String {
-        format!("__DATA,__linkme{}", crate::hash(ident))
+        format!("__DATA,__linkme{},regular,no_dead_strip", crate::hash(ident))
     }
 
     pub fn section_start(ident: &Ident) -> String {


### PR DESCRIPTION
This adds the `S_ATTR_NO_DEAD_STRIP` section attribute, which forces "unused" code to remain in the binary. This is paired with `S_REGULAR` to provide a required section type.

This fixes #41.