### PR TITLE
Panic if multiple distributed slices with same name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@
     clippy::doc_markdown,
     clippy::empty_enum,
     clippy::expl_impl_clone_on_copy,
+    clippy::manual_assert,
     clippy::missing_panics_doc,
     clippy::must_use_candidate,
     clippy::unused_self

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,5 +1,6 @@
 pub use core::assert;
 pub use core::mem;
+pub use core::primitive::usize;
 
 pub trait Slice {
     type Element;


### PR DESCRIPTION
Example:

```rust
// dependency:

use linkme::distributed_slice;

#[distributed_slice]
pub static STUFF: [u128] = [..];

#[distributed_slice(STUFF)]
static ELEMENT: u128 = u128::MAX;
```

```rust
// main.rs:

extern crate dependency;

use linkme::distributed_slice;

#[distributed_slice]
pub static STUFF: [&'static str] = [..];

#[distributed_slice(STUFF)]
static ELEMENT: &'static str = "...";

fn main() {
    for thing in STUFF {
        println!("{}", thing);
    }
}
```

### Before:

```console
...
Segmentation fault (core dumped)
```

### After:

```console
thread 'main' panicked at 'duplicate #[distributed_slice] with name "STUFF"'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Closes #3.

If somebody has a use case, it's possible we could do something fancier than this by checking whether every distributed slice with the same name has the same `TypeId`, and only panicking if different.