### PR TITLE
Match Windows start/stop to interior mutability of the element type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ used_linker = ["linkme-impl/used_linker"]
 linkme-impl = { version = "=0.3.5", path = "impl" }
 
 [dev-dependencies]
+once_cell = "1.16"
 rustversion = "1.0"
 trybuild = { version = "1.0.66", features = ["diff"] }
 

--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -149,11 +149,11 @@ pub fn expand(input: TokenStream) -> TokenStream {
 
             #[cfg(target_os = "windows")]
             #[link_section = #windows_section_start]
-            static LINKME_START: () = ();
+            static LINKME_START: [<#ty as #linkme_path::__private::Slice>::Element; 0] = [];
 
             #[cfg(target_os = "windows")]
             #[link_section = #windows_section_stop]
-            static LINKME_STOP: () = ();
+            static LINKME_STOP: [<#ty as #linkme_path::__private::Slice>::Element; 0] = [];
 
             #[cfg(target_os = "windows")]
             #[link_section = #windows_dupcheck_start]

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -186,8 +186,8 @@ impl<T> DistributedSlice<[T]> {
     #[cfg(target_os = "windows")]
     pub const unsafe fn private_new(
         name: &'static str,
-        section_start: *const (),
-        section_stop: *const (),
+        section_start: *const [T; 0],
+        section_stop: *const [T; 0],
         dupcheck_start: *const (),
         dupcheck_stop: *const (),
     ) -> Self {

--- a/tests/distributed_slice.rs
+++ b/tests/distributed_slice.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
 
 use linkme::distributed_slice;
+use once_cell::sync::Lazy;
 
 #[distributed_slice]
 static SHENANIGANS: [i32] = [..];
@@ -45,4 +46,16 @@ fn test_non_copy() {
     static ELEMENT: NonCopy = NonCopy(9);
 
     assert!(!NONCOPY.is_empty());
+}
+
+#[test]
+fn test_interior_mutable() {
+    #[distributed_slice]
+    static MUTABLE: [Lazy<i32>] = [..];
+
+    #[distributed_slice(MUTABLE)]
+    static ELEMENT: Lazy<i32> = Lazy::new(|| -1);
+
+    assert!(MUTABLE.len() == 1);
+    assert!(*MUTABLE[0] == -1);
 }


### PR DESCRIPTION
Possibly relevant to #57.