### PR TITLE
Windows: Prevent pointer provenance "optimization"

### DIFF
--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -268,6 +268,12 @@ impl<T> DistributedSlice<[T]> {
             // using the unsafe `private_new`.
             None => unsafe { hint::unreachable_unchecked() },
         };
+
+        // On Windows, make sure we discard provenance information.
+        // Otherwise, the compiler has enough information to see we are going "out of bounds".
+        #[cfg(target_os = "windows")]
+        let start = core::hint::black_box(start);
+
         unsafe { slice::from_raw_parts(start, len) }
     }
 }

--- a/tests/distributed_slice.rs
+++ b/tests/distributed_slice.rs
@@ -69,4 +69,5 @@ fn test_elided_lifetime() {
     static ELEMENT: &str = "...";
 
     assert!(!MYSLICE.is_empty());
+    assert_eq!(MYSLICE[0], "...");
 }


### PR DESCRIPTION
On Windows, we can't just use extern symbols for our "start" and "end" pointers; we have to define them within the module. The current implementation uses a zero-length array for that. However, the compiler can track uses of that pointer through the creation of the distributed slice, and will optimize out accesses that are "out of bounds". Pass the pointer through `core::mem::black_box` to prevent this.

Potentially a fix for #67, which has similar symptoms. Our project likewise failed under LTO and passed normally, but this test change fails for me without the fix even with LTO turned off.