### PR TITLE
Allow `= [..]` to be omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ must be `[..]` to indicate that elements come from elsewhere.
 use linkme::distributed_slice;
 
 #[distributed_slice]
-pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
+pub static BENCHMARKS: [fn(&mut Bencher)];
 ```
 
 ### Elements
@@ -120,7 +120,7 @@ definition to place a pointer to that function into a distributed slice.
 use linkme::distributed_slice;
 
 #[distributed_slice]
-pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
+pub static BENCHMARKS: [fn(&mut Bencher)];
 
 // Equivalent to:
 //

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ operates entirely during compilation and linking.
 ### Declaration
 
 A static distributed slice is declared by writing `#[distributed_slice]` on a
-static item whose type is `[T]` for some type `T`. The initializer expression
-must be `[..]` to indicate that elements come from elsewhere.
+static item whose type is `[T]` for some type `T`.
 
 ```rust
 use linkme::distributed_slice;

--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -29,11 +29,13 @@ impl Parse for Declaration {
         let ident: Ident = input.parse()?;
         input.parse::<Token![:]>()?;
         let ty: Type = input.parse()?;
-        input.parse::<Token![=]>()?;
 
-        let content;
-        bracketed!(content in input);
-        content.parse::<Token![..]>()?;
+        let eq_token: Option<Token![=]> = input.parse()?;
+        if eq_token.is_some() {
+            let content;
+            bracketed!(content in input);
+            content.parse::<Token![..]>()?;
+        }
 
         input.parse::<Token![;]>()?;
 

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -27,7 +27,7 @@ use crate::__private::Slice;
 /// use linkme::distributed_slice;
 ///
 /// #[distributed_slice]
-/// pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
+/// pub static BENCHMARKS: [fn(&mut Bencher)];
 /// ```
 ///
 /// The attribute rewrites the `[T]` type of the static into
@@ -54,7 +54,7 @@ use crate::__private::Slice;
 /// #     pub struct Bencher;
 /// #
 /// #     #[distributed_slice]
-/// #     pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
+/// #     pub static BENCHMARKS: [fn(&mut Bencher)];
 /// # }
 /// #
 /// # use other_crate::Bencher;
@@ -81,7 +81,7 @@ use crate::__private::Slice;
 /// #     pub struct Bencher;
 /// #
 /// #     #[distributed_slice]
-/// #     pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
+/// #     pub static BENCHMARKS: [fn(&mut Bencher)];
 /// # }
 /// #
 /// # use linkme::distributed_slice;
@@ -117,7 +117,7 @@ use crate::__private::Slice;
 /// use linkme::distributed_slice;
 ///
 /// #[distributed_slice]
-/// pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
+/// pub static BENCHMARKS: [fn(&mut Bencher)];
 ///
 /// // Equivalent to:
 /// //
@@ -235,7 +235,7 @@ impl<T> DistributedSlice<[T]> {
     /// use linkme::distributed_slice;
     ///
     /// #[distributed_slice]
-    /// static BENCHMARKS: [fn(&mut Bencher)] = [..];
+    /// static BENCHMARKS: [fn(&mut Bencher)];
     ///
     /// fn main() {
     ///     // Iterate the elements.

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -16,8 +16,7 @@ use crate::__private::Slice;
 /// ## Declaration
 ///
 /// A static distributed slice may be declared by writing `#[distributed_slice]`
-/// on a static item whose type is `[T]` for some type `T`. The initializer
-/// expression must be `[..]` to indicate that elements come from elsewhere.
+/// on a static item whose type is `[T]` for some type `T`.
 ///
 /// ```
 /// # #![cfg_attr(feature = "used_linker", feature(used_with_arg))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! use linkme::distributed_slice;
 //!
 //! #[distributed_slice]
-//! pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
+//! pub static BENCHMARKS: [fn(&mut Bencher)];
 //! ```
 //!
 //! Slice elements may be registered into a distributed slice by a
@@ -60,7 +60,7 @@
 //! #     pub struct Bencher;
 //! #
 //! #     #[distributed_slice]
-//! #     pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
+//! #     pub static BENCHMARKS: [fn(&mut Bencher)];
 //! # }
 //! #
 //! # use other_crate::Bencher;
@@ -86,7 +86,7 @@
 //! # struct Bencher;
 //! #
 //! # #[distributed_slice]
-//! # static BENCHMARKS: [fn(&mut Bencher)] = [..];
+//! # static BENCHMARKS: [fn(&mut Bencher)];
 //! #
 //! fn main() {
 //!     // Iterate the elements.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,7 @@
 //! of the API. The basic idea is as follows.
 //!
 //! A static distributed slice is declared by writing `#[distributed_slice]` on
-//! a static item whose type is `[T]` for some type `T`. The initializer
-//! expression must be `[..]` to indicate that elements come from elsewhere.
+//! a static item whose type is `[T]` for some type `T`.
 //!
 //! ```
 //! # #![cfg_attr(feature = "used_linker", feature(used_with_arg))]

--- a/tests/cortex/src/main.rs
+++ b/tests/cortex/src/main.rs
@@ -10,7 +10,7 @@ use cortex_m_semihosting::{debug, hprintln};
 use linkme::distributed_slice;
 
 #[distributed_slice]
-static SHENANIGANS: [i32] = [..];
+static SHENANIGANS: [i32];
 
 #[distributed_slice(SHENANIGANS)]
 static N: i32 = 9;
@@ -33,7 +33,7 @@ fn main() -> ! {
     assert_eq!(sum, 9 + 99 + 999);
 
     #[distributed_slice]
-    static EMPTY: [i32] = [..];
+    static EMPTY: [i32];
 
     assert!(EMPTY.is_empty());
 

--- a/tests/cortex/src/main.rs
+++ b/tests/cortex/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     assert_eq!(sum, 9 + 99 + 999);
 
     #[distributed_slice]
-    static EMPTY: [i32];
+    static EMPTY: [i32] = [..];
 
     assert!(EMPTY.is_empty());
 

--- a/tests/custom_linkme_path.rs
+++ b/tests/custom_linkme_path.rs
@@ -7,7 +7,7 @@ mod declaration {
 
     #[distributed_slice]
     #[linkme(crate = crate::link_me)]
-    pub static SLICE: [i32] = [..];
+    pub static SLICE: [i32];
 
     #[test]
     fn test_slice() {
@@ -16,7 +16,7 @@ mod declaration {
 
     #[distributed_slice]
     #[linkme(crate = crate::link_me)]
-    pub static FUNCTIONS: [fn()] = [..];
+    pub static FUNCTIONS: [fn()];
 
     #[test]
     fn test_functions() {

--- a/tests/distributed_slice.rs
+++ b/tests/distributed_slice.rs
@@ -4,7 +4,7 @@ use linkme::distributed_slice;
 use once_cell::sync::Lazy;
 
 #[distributed_slice]
-static SHENANIGANS: [i32] = [..];
+static SHENANIGANS: [i32];
 
 #[distributed_slice(SHENANIGANS)]
 static N: i32 = 9;
@@ -30,7 +30,7 @@ fn test() {
 #[test]
 fn test_empty() {
     #[distributed_slice]
-    static EMPTY: [i32] = [..];
+    static EMPTY: [i32];
 
     assert!(EMPTY.is_empty());
 }
@@ -40,7 +40,7 @@ fn test_non_copy() {
     struct NonCopy(i32);
 
     #[distributed_slice]
-    static NONCOPY: [NonCopy] = [..];
+    static NONCOPY: [NonCopy];
 
     #[distributed_slice(NONCOPY)]
     static ELEMENT: NonCopy = NonCopy(9);
@@ -51,7 +51,7 @@ fn test_non_copy() {
 #[test]
 fn test_interior_mutable() {
     #[distributed_slice]
-    static MUTABLE: [Lazy<i32>] = [..];
+    static MUTABLE: [Lazy<i32>];
 
     #[distributed_slice(MUTABLE)]
     static ELEMENT: Lazy<i32> = Lazy::new(|| -1);
@@ -63,7 +63,7 @@ fn test_interior_mutable() {
 #[test]
 fn test_elided_lifetime() {
     #[distributed_slice]
-    pub static MYSLICE: [&str] = [..];
+    pub static MYSLICE: [&str];
 
     #[distributed_slice(MYSLICE)]
     static ELEMENT: &str = "...";

--- a/tests/distributed_slice.rs
+++ b/tests/distributed_slice.rs
@@ -71,3 +71,10 @@ fn test_elided_lifetime() {
     assert!(!MYSLICE.is_empty());
     assert_eq!(MYSLICE[0], "...");
 }
+
+#[test]
+fn test_legacy_syntax() {
+    // Rustc older than 1.43 requires an initializer expression.
+    #[distributed_slice]
+    pub static LEGACY: [&str] = [..];
+}

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -7,7 +7,7 @@ use linkme::distributed_slice;
 pub struct Bencher;
 
 #[distributed_slice]
-pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
+pub static BENCHMARKS: [fn(&mut Bencher)];
 
 #[distributed_slice(BENCHMARKS)]
 static BENCH_DESERIALIZE: fn(&mut Bencher) = bench_deserialize;

--- a/tests/fn_element.rs
+++ b/tests/fn_element.rs
@@ -4,19 +4,19 @@
 use linkme::distributed_slice;
 
 #[distributed_slice]
-pub static SLICE1: [fn()] = [..];
+pub static SLICE1: [fn()];
 
 #[distributed_slice(SLICE1)]
 fn foo() {}
 
 #[distributed_slice]
-pub static SLICE2: [for<'a, 'b> fn(&'a &'b ())] = [..];
+pub static SLICE2: [for<'a, 'b> fn(&'a &'b ())];
 
 #[distributed_slice(SLICE2)]
 fn bar<'a, 'b>(_: &'a &'b ()) {}
 
 #[distributed_slice]
-pub static SLICE3: [unsafe extern "C" fn() -> i32] = [..];
+pub static SLICE3: [unsafe extern "C" fn() -> i32];
 
 #[distributed_slice(SLICE3)]
 unsafe extern "C" fn baz() -> i32 {

--- a/tests/module/mod.rs
+++ b/tests/module/mod.rs
@@ -2,7 +2,7 @@ mod declaration {
     use linkme::distributed_slice;
 
     #[distributed_slice]
-    pub static SLICE: [i32] = [..];
+    pub static SLICE: [i32];
 
     #[test]
     fn test_mod_slice() {

--- a/tests/ui/bad_crate_path.rs
+++ b/tests/ui/bad_crate_path.rs
@@ -8,10 +8,10 @@ mod path {
 
 #[distributed_slice]
 #[linkme(crate = path::to::missing)]
-pub static SLICE1: [&'static str] = [..];
+pub static SLICE1: [&'static str];
 
 #[distributed_slice]
-pub static SLICE2: [&'static str] = [..];
+pub static SLICE2: [&'static str];
 
 #[distributed_slice(SLICE2)]
 #[linkme(crate = path::to::missing)]

--- a/tests/ui/generic_fn.rs
+++ b/tests/ui/generic_fn.rs
@@ -3,7 +3,7 @@
 use linkme::distributed_slice;
 
 #[distributed_slice]
-pub static SLICES: [fn()] = [..];
+pub static SLICES: [fn()];
 
 #[distributed_slice(SLICES)]
 fn type_param<T>() {}

--- a/tests/ui/mismatched_types.rs
+++ b/tests/ui/mismatched_types.rs
@@ -5,7 +5,7 @@ use linkme::distributed_slice;
 pub struct Bencher;
 
 #[distributed_slice]
-pub static BENCHMARKS: [fn(&mut Bencher)] = [..];
+pub static BENCHMARKS: [fn(&mut Bencher)];
 
 #[distributed_slice(BENCHMARKS)]
 static BENCH_WTF: usize = 999;

--- a/tests/ui/mutable.rs
+++ b/tests/ui/mutable.rs
@@ -3,7 +3,7 @@
 use linkme::distributed_slice;
 
 #[distributed_slice]
-pub static mut SLICE: [i32] = [..];
+pub static mut SLICE: [i32];
 
 #[distributed_slice(BENCHMARKS)]
 static mut ELEMENT: i32 = -1;

--- a/tests/ui/mutable.stderr
+++ b/tests/ui/mutable.stderr
@@ -1,7 +1,7 @@
 error: static mut is not supported by distributed_slice
  --> tests/ui/mutable.rs:6:12
   |
-6 | pub static mut SLICE: [i32] = [..];
+6 | pub static mut SLICE: [i32];
   |            ^^^
 
 error: static mut is not supported by distributed_slice

--- a/tests/ui/unsupported_item.rs
+++ b/tests/ui/unsupported_item.rs
@@ -3,7 +3,7 @@
 use linkme::distributed_slice;
 
 #[distributed_slice]
-pub static SLICE: [&'static str] = [..];
+pub static SLICE: [&'static str];
 
 #[distributed_slice(SLICE)]
 extern crate std as _std;

--- a/tests/ui/zerosized.rs
+++ b/tests/ui/zerosized.rs
@@ -5,6 +5,6 @@ use linkme::distributed_slice;
 pub struct Unit;
 
 #[distributed_slice]
-pub static ZEROSIZED: [Unit] = [..];
+pub static ZEROSIZED: [Unit];
 
 fn main() {}

--- a/tests/win_status_access_violation.rs
+++ b/tests/win_status_access_violation.rs
@@ -3,7 +3,7 @@
 use linkme::distributed_slice;
 
 #[distributed_slice]
-static ITEMS: [&'static str] = [..];
+static ITEMS: [&'static str];
 
 #[distributed_slice(ITEMS)]
 static ITEM1: &'static str = "item1";

--- a/tests/win_status_illegal_instruction.rs
+++ b/tests/win_status_illegal_instruction.rs
@@ -14,7 +14,7 @@ impl Item {
 }
 
 #[distributed_slice]
-static ITEMS: [Item] = [..];
+static ITEMS: [Item];
 
 #[distributed_slice(ITEMS)]
 static ITEM1: Item = Item { name: "item1" };


### PR DESCRIPTION
Supported since https://github.com/rust-lang/rust/pull/69194 (Rust 1.43).