### PR TITLE
Use = [..] in example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! use linkme::distributed_slice;
 //!
 //! #[distributed_slice]
-//! pub static BENCHMARKS: [fn(&mut Bencher)];
+//! pub static BENCHMARKS: [fn(&mut Bencher)] = [..]; // `= [..]` is optional.
 //! ```
 //!
 //! Slice elements may be registered into a distributed slice by a


### PR DESCRIPTION
CLion likes this syntax more because it is valid before proc macro:

For the reference, this is how it looks like in CLion:

<img width="280" alt="image" src="https://github.com/dtolnay/linkme/assets/28969/25d824cb-598f-4b47-8838-0ecdac068b83">
