### PR TITLE
Turn on deny(unsafe_op_in_unsafe_fn)

### DIFF
--- a/impl/src/element.rs
+++ b/impl/src/element.rs
@@ -230,7 +230,9 @@ fn do_expand(path: Path, pos: Option<usize>, input: Element) -> TokenStream {
                 #[allow(clippy::no_effect_underscore_binding)]
                 unsafe fn __typecheck(_: #linkme_path::__private::Void) {
                     let #new = #linkme_path::__private::value::<#ty>;
-                    #linkme_path::DistributedSlice::private_typecheck(#path, #uninit)
+                    unsafe {
+                        #linkme_path::DistributedSlice::private_typecheck(#path, #uninit);
+                    }
                 }
 
                 #expr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/linkme/0.3.19")]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(
     clippy::doc_markdown,
     clippy::empty_enum,

--- a/tests/distributed_slice.rs
+++ b/tests/distributed_slice.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use linkme::distributed_slice;
 use once_cell::sync::Lazy;


### PR DESCRIPTION
This is allow-by-default for now in 2021 edition, but will become warn-by-default in 2024 edition.