### PR TITLE
Add support for `mipsel-sony-psp`

### DIFF
--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -129,27 +129,28 @@ pub fn expand(input: TokenStream) -> TokenStream {
                 target_os = "fuchsia",
                 target_os = "illumos",
                 target_os = "freebsd",
+                target_os = "psp",
             ))]
             extern "Rust" {
-                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia"), link_name = #linux_section_start)]
+                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia", target_os = "psp"), link_name = #linux_section_start)]
                 #[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"), link_name = #macho_section_start)]
                 #[cfg_attr(target_os = "illumos", link_name = #illumos_section_start)]
                 #[cfg_attr(target_os = "freebsd", link_name = #freebsd_section_start)]
                 static LINKME_START: <#ty as #linkme_path::__private::Slice>::Element;
 
-                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia"), link_name = #linux_section_stop)]
+                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia", target_os = "psp"), link_name = #linux_section_stop)]
                 #[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"), link_name = #macho_section_stop)]
                 #[cfg_attr(target_os = "illumos", link_name = #illumos_section_stop)]
                 #[cfg_attr(target_os = "freebsd", link_name = #freebsd_section_stop)]
                 static LINKME_STOP: <#ty as #linkme_path::__private::Slice>::Element;
 
-                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia"), link_name = #linux_dupcheck_start)]
+                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia", target_os = "psp"), link_name = #linux_dupcheck_start)]
                 #[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"), link_name = #macho_dupcheck_start)]
                 #[cfg_attr(target_os = "illumos", link_name = #illumos_dupcheck_start)]
                 #[cfg_attr(target_os = "freebsd", link_name = #freebsd_dupcheck_start)]
                 static DUPCHECK_START: #linkme_path::__private::usize;
 
-                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia"), link_name = #linux_dupcheck_stop)]
+                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia", target_os = "psp"), link_name = #linux_dupcheck_stop)]
                 #[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"), link_name = #macho_dupcheck_stop)]
                 #[cfg_attr(target_os = "illumos", link_name = #illumos_dupcheck_stop)]
                 #[cfg_attr(target_os = "freebsd", link_name = #freebsd_dupcheck_stop)]
@@ -173,14 +174,14 @@ pub fn expand(input: TokenStream) -> TokenStream {
             static DUPCHECK_STOP: () = ();
 
             #used
-            #[cfg(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "illumos", target_os = "freebsd"))]
-            #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia"), link_section = #linux_section)]
+            #[cfg(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "illumos", target_os = "freebsd", target_os = "psp"))]
+            #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia", target_os = "psp"), link_section = #linux_section)]
             #[cfg_attr(target_os = "illumos", link_section = #illumos_section)]
             #[cfg_attr(target_os = "freebsd", link_section = #freebsd_section)]
             static mut LINKME_PLEASE: [<#ty as #linkme_path::__private::Slice>::Element; 0] = [];
 
             #used
-            #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia"), link_section = #linux_dupcheck)]
+            #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia", target_os = "psp"), link_section = #linux_dupcheck)]
             #[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"), link_section = #macho_dupcheck)]
             #[cfg_attr(target_os = "windows", link_section = #windows_dupcheck)]
             #[cfg_attr(target_os = "illumos", link_section = #illumos_dupcheck)]
@@ -198,6 +199,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
                 target_os = "fuchsia",
                 target_os = "illumos",
                 target_os = "freebsd",
+                target_os = "psp",
             )))]
             #unsupported_platform
 
@@ -242,7 +244,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
                 $item:item
             ) => {
                 #used
-                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia"), link_section = $linux_section)]
+                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia", target_os = "psp"), link_section = $linux_section)]
                 #[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"), link_section = $macho_section)]
                 #[cfg_attr(target_os = "windows", link_section = $windows_section)]
                 #[cfg_attr(target_os = "illumos", link_section = $illumos_section)]
@@ -251,7 +253,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
             };
             ($item:item) => {
                 #used
-                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia"), link_section = #linux_section)]
+                #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia", target_os = "psp"), link_section = #linux_section)]
                 #[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"), link_section = #macho_section)]
                 #[cfg_attr(target_os = "windows", link_section = #windows_section)]
                 #[cfg_attr(target_os = "illumos", link_section = #illumos_section)]

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -163,7 +163,8 @@ impl<T> DistributedSlice<[T]> {
         target_os = "android",
         target_os = "fuchsia",
         target_os = "illumos",
-        target_os = "freebsd"
+        target_os = "freebsd",
+        target_os = "psp",
     ))]
     pub const unsafe fn private_new(
         name: &'static str,


### PR DESCRIPTION
I wanted to use this to build a test runner for `mipsel-sony-psp` targets and figured I'd upstream. Requires `#![feature(used_with_arg)]` to be used for correct linking. 🙂 