### PR TITLE
Prevent coercion before distributed slice typecheck

### DIFF
--- a/impl/src/element.rs
+++ b/impl/src/element.rs
@@ -228,7 +228,7 @@ fn do_expand(path: Path, pos: Option<usize>, input: Element) -> TokenStream {
             #vis static #ident : #ty = {
                 #[allow(clippy::no_effect_underscore_binding)]
                 unsafe fn __typecheck(_: #linkme_path::__private::Void) {
-                    let #new = #linkme_path::__private::value::<#ty>;
+                    let #new = || (|| &#ident) as fn() -> _;
                     unsafe {
                         #linkme_path::DistributedSlice::private_typecheck(#path, #uninit);
                     }

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -212,8 +212,8 @@ impl<T> DistributedSlice<[T]> {
 
     #[doc(hidden)]
     #[inline]
-    pub unsafe fn private_typecheck(self, element: T) {
-        mem::forget(element);
+    pub unsafe fn private_typecheck(self, get: fn() -> &'static T) {
+        let _ = get;
     }
 }
 

--- a/tests/ui/attempted_coercion.rs
+++ b/tests/ui/attempted_coercion.rs
@@ -1,0 +1,11 @@
+#![cfg_attr(feature = "used_linker", feature(used_with_arg))]
+
+use linkme::distributed_slice;
+
+#[distributed_slice]
+pub static SLICE: [&'static str];
+
+#[distributed_slice(SLICE)]
+static ELEMENT: &&str = &"uhoh";
+
+fn main() {}

--- a/tests/ui/attempted_coercion.stderr
+++ b/tests/ui/attempted_coercion.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+ --> tests/ui/attempted_coercion.rs:9:17
+  |
+8 | #[distributed_slice(SLICE)]
+  | --------------------------- arguments to this function are incorrect
+9 | static ELEMENT: &&str = &"uhoh";
+  |                 ^^^^^ expected `str`, found `&str`
+  |
+  = note: expected fn pointer `fn() -> &'static &'static _`
+             found fn pointer `fn() -> &&&_`
+note: method defined here
+ --> src/distributed_slice.rs
+  |
+  |     pub unsafe fn private_typecheck(self, get: fn() -> &'static T) {
+  |                   ^^^^^^^^^^^^^^^^^

--- a/tests/ui/mismatched_types.stderr
+++ b/tests/ui/mismatched_types.stderr
@@ -6,12 +6,12 @@ error[E0308]: mismatched types
 11 | static BENCH_WTF: usize = 999;
    |                   ^^^^^ expected fn pointer, found `usize`
    |
-   = note: expected fn pointer `for<'a> fn(&'a mut Bencher)`
-                    found type `usize`
+   = note: expected fn pointer `fn() -> &'static for<'a> fn(&'a mut Bencher)`
+              found fn pointer `fn() -> &usize`
 note: method defined here
   --> src/distributed_slice.rs
    |
-   |     pub unsafe fn private_typecheck(self, element: T) {
+   |     pub unsafe fn private_typecheck(self, get: fn() -> &'static T) {
    |                   ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
@@ -22,10 +22,10 @@ error[E0308]: mismatched types
 14 | fn wrong_bench_fn<'a>(_: &'a mut ()) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Bencher`, found `()`
    |
-   = note: expected fn pointer `for<'a> fn(&'a mut Bencher)`
-              found fn pointer `for<'a> fn(&'a mut ())`
+   = note: expected fn pointer `fn() -> &'static for<'a> fn(&'a mut Bencher)`
+              found fn pointer `fn() -> &for<'a> fn(&'a mut ())`
 note: method defined here
   --> src/distributed_slice.rs
    |
-   |     pub unsafe fn private_typecheck(self, element: T) {
+   |     pub unsafe fn private_typecheck(self, get: fn() -> &'static T) {
    |                   ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #82 

We use a `fn() -> &T` to prevent value coercions from applying. This does allow contravariant coercion to a subtype (a shorter lifetime), but I *believe* that since `#ty` is in a `static` (cannot contain lifetimes other than the top lifetime `'static`) that this is not an exploitable hole. If a hole remains, it's probably to do with `for<'a>` lifetime binders.

I did test a few methods that fully constrain `T` to be invariant (e.g. `fn(T) -> T`), but they all worsened the error messages more than this does, and this appears to be sufficient.