### PR TITLE
Further improve slice typecheck

### DIFF
--- a/impl/src/element.rs
+++ b/impl/src/element.rs
@@ -1,4 +1,4 @@
-use crate::attr;
+use crate::{attr, ty};
 use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::{format_ident, quote, quote_spanned};
 use syn::parse::{Error, Parse, ParseStream, Result};
@@ -204,9 +204,11 @@ fn do_expand(path: Path, pos: Option<usize>, input: Element) -> TokenStream {
     let mut attrs = input.attrs;
     let vis = input.vis;
     let ident = input.ident;
-    let ty = input.ty;
+    let mut ty = input.ty;
     let expr = input.expr;
     let orig_item = input.orig_item;
+
+    ty::populate_static_lifetimes(&mut ty);
 
     let linkme_path = match attr::linkme_path(&mut attrs) {
         Ok(path) => path,
@@ -215,8 +217,8 @@ fn do_expand(path: Path, pos: Option<usize>, input: Element) -> TokenStream {
 
     let sort_key = pos.into_iter().map(|pos| format!("{:04}", pos));
 
-    let new = quote_spanned!(input.start_span=> __new);
-    let uninit = quote_spanned!(input.end_span=> #new());
+    let factory = quote_spanned!(input.start_span=> __new);
+    let get = quote_spanned!(input.end_span=> #factory());
 
     quote! {
         #path ! {
@@ -228,9 +230,9 @@ fn do_expand(path: Path, pos: Option<usize>, input: Element) -> TokenStream {
             #vis static #ident : #ty = {
                 #[allow(clippy::no_effect_underscore_binding)]
                 unsafe fn __typecheck(_: #linkme_path::__private::Void) {
-                    let #new = || (|| &#ident) as fn() -> _;
+                    let #factory = || -> fn() -> &'static #ty { || &#ident };
                     unsafe {
-                        #linkme_path::DistributedSlice::private_typecheck(#path, #uninit);
+                        #linkme_path::DistributedSlice::private_typecheck(#path, #get);
                     }
                 }
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -12,6 +12,7 @@ mod declaration;
 mod element;
 mod hash;
 mod linker;
+mod ty;
 
 use crate::args::Args;
 use crate::hash::hash;

--- a/impl/src/ty.rs
+++ b/impl/src/ty.rs
@@ -1,0 +1,42 @@
+use syn::{GenericArgument, Lifetime, PathArguments, Type};
+
+pub(crate) fn populate_static_lifetimes(ty: &mut Type) {
+    match ty {
+        #![cfg_attr(all(test, exhaustive), deny(non_exhaustive_omitted_patterns))]
+        Type::Array(ty) => populate_static_lifetimes(&mut ty.elem),
+        Type::Group(ty) => populate_static_lifetimes(&mut ty.elem),
+        Type::Paren(ty) => populate_static_lifetimes(&mut ty.elem),
+        Type::Path(ty) => {
+            if let Some(qself) = &mut ty.qself {
+                populate_static_lifetimes(&mut qself.ty);
+            }
+            for segment in &mut ty.path.segments {
+                if let PathArguments::AngleBracketed(segment) = &mut segment.arguments {
+                    for arg in &mut segment.args {
+                        if let GenericArgument::Type(arg) = arg {
+                            populate_static_lifetimes(arg);
+                        }
+                    }
+                }
+            }
+        }
+        Type::Ptr(ty) => populate_static_lifetimes(&mut ty.elem),
+        Type::Reference(ty) => {
+            if ty.lifetime.is_none() {
+                ty.lifetime = Some(Lifetime::new("'static", ty.and_token.span));
+            }
+            populate_static_lifetimes(&mut ty.elem);
+        }
+        Type::Slice(ty) => populate_static_lifetimes(&mut ty.elem),
+        Type::Tuple(ty) => ty.elems.iter_mut().for_each(populate_static_lifetimes),
+        Type::ImplTrait(_)
+        | Type::Infer(_)
+        | Type::Macro(_)
+        | Type::Never(_)
+        | Type::TraitObject(_)
+        | Type::BareFn(_)
+        | Type::Verbatim(_) => {}
+
+        _ => unimplemented!("unknown Type"),
+    }
+}

--- a/src/private.rs
+++ b/src/private.rs
@@ -18,8 +18,3 @@ impl<T> Slice for [T] {
 
 #[doc(hidden)]
 pub enum Void {}
-
-#[doc(hidden)]
-pub fn value<T>() -> T {
-    panic!()
-}

--- a/tests/ui/attempted_coercion.stderr
+++ b/tests/ui/attempted_coercion.stderr
@@ -4,10 +4,10 @@ error[E0308]: mismatched types
 8 | #[distributed_slice(SLICE)]
   | --------------------------- arguments to this function are incorrect
 9 | static ELEMENT: &&str = &"uhoh";
-  |                 ^^^^^ expected `str`, found `&str`
+  |                 ^^^^^ expected `str`, found `&'static str`
   |
   = note: expected fn pointer `fn() -> &'static &'static _`
-             found fn pointer `fn() -> &&&_`
+             found fn pointer `fn() -> &'static &'static &'static _`
 note: method defined here
  --> src/distributed_slice.rs
   |

--- a/tests/ui/mismatched_types.stderr
+++ b/tests/ui/mismatched_types.stderr
@@ -7,7 +7,7 @@ error[E0308]: mismatched types
    |                   ^^^^^ expected fn pointer, found `usize`
    |
    = note: expected fn pointer `fn() -> &'static for<'a> fn(&'a mut Bencher)`
-              found fn pointer `fn() -> &usize`
+              found fn pointer `fn() -> &'static usize`
 note: method defined here
   --> src/distributed_slice.rs
    |
@@ -23,7 +23,7 @@ error[E0308]: mismatched types
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Bencher`, found `()`
    |
    = note: expected fn pointer `fn() -> &'static for<'a> fn(&'a mut Bencher)`
-              found fn pointer `fn() -> &for<'a> fn(&'a mut ())`
+              found fn pointer `fn() -> &'static for<'a> fn(&'a mut ())`
 note: method defined here
   --> src/distributed_slice.rs
    |


### PR DESCRIPTION
Follow-up to #83. There's two minor motivations to the change here:

- Protect against future changes to coercion/inference. By fully specifying the function pointer type, we can ensure that no coercion happens before the closure captures `&#ty`.
  - e.g. inserting an explicit coercion point with `(|| &#ident as _)` causes the current tyck to fail.
- Improve the error message by populating `'static` lifetimes, making the type mismatch more directly comparable.

Also removes `linkme::__private::value`, as that helper function is no longer used.

The chance that a coercion could break the check done by #83 is reasonably low and would be caught on CI, and the error improvement is debatable at best, so it's a judgement call on whether these changes should be merged.

