### PR TITLE
Disable rust-lld in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Enable type layout randomization
         run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
         if: matrix.rust == 'nightly'
+      - name: Disable rust-lld
+        run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
+        if: matrix.rust == 'nightly'
       - run: cargo check --manifest-path tests/crate/Cargo.toml
       - run: cargo test -p linkme -p linkme-impl
         # windows-gnu: https://github.com/dtolnay/linkme/issues/25


### PR DESCRIPTION
With rust-lld (https://github.com/rust-lang/rust/pull/124129), `cargo build --test example` is currently failing to link.

```console
$ cargo build --test example
error: linking with `cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/self-contained:~/.wasmtime/bin:~/.nvm/versions/node/v20.11.0/bin:~/bin:~/.cargo/bin:~/.cargo/bin:~/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin:~/go/bin" VSLANG="1033" "cc" "-m64" "/tmp/rustcube7yt/symbols.o" "target/debug/deps/example-7fc4473584324aeb.16i0ej164hkitesrfehy9w1pi.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.1d5hd0p7tpecex7fcezpgrwi1.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.1pz0kbu3vnfqd8cak4o0wdbge.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.1xm8j8de8igadyswmbe7kv7ir.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.2cf6q1wqutkaovb07ne9iduhu.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.2dye8cv3o184649vml50hakc3.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.2ouedh44ce3xg2shb6dhkv7f3.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.40wq060yotkfawqpv5yvyw2tc.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.43sjzuz0nbbwv7af4tcnq2qbd.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.4cf58czkoggp0617q67z3sgty.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.4mo8w9xxxku8sfhlzcbbwhi74.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.4q77mhdbufd91c25qt20aud7n.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.5aq3t9cdvpp08h3y9fz9645aj.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.5mu1g179pbxjaod5bzoaxxj1v.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.5umc3w2s4z7xvsbrhpjm1kgn6.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.6gvmxrx0ktpl65yudlx4xu7ot.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.6pgize7471kwthjs7hx7989d5.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.7t8yuv1qvg89aohzkr9hcgjtd.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.85ysdi3oerszh3appz0f33ath.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.8bf33mbplpu7mt6bgt2t89vx0.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.a1bekdq760d1xiv08fk4sw8pk.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.a5lqhnqflm3ktoakxhmcs8r2v.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.b3q0ez4dp538af7vlo9hwpynu.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.bmvbl6z9dwai5fcdejhxuli80.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.c15nvri45gxys20fbq3t21b18.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.cg35476roirved24o6mkw5q6s.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.d1rbztf498p2vwfhuakv0jd34.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.dkrpdc60u7h4khr2jv7uhli83.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.dmoc3o99gkdm28u91l3ot8an2.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.dnbqpkjhtdfrc9kz99owfu9sl.rcgu.o" "target/debug/deps/example-7fc4473584324aeb.5r3yttgfr7zib2hw4vygshc0p.rcgu.o" "-Wl,--as-needed" "-L" "target/debug/deps" "-L" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libtest-9fe2882344d54f63.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgetopts-9a21fdde14ac91dc.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunicode_width-df7cac1850604c78.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_std-2f3836017b2380f6.rlib" "target/debug/deps/liblinkme-a4ec15bed7c945e0.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-de48b8168d6cf4fa.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_unwind-9f3477fb95a0bba7.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libobject-210d920812faea91.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libmemchr-f3d3451767410a17.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libaddr2line-1a79dd36d08251de.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-886230e7120831b2.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_demangle-2caea079085a58a2.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd_detect-a9d7d97cdc65a449.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libhashbrown-5727477b0a78105a.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_alloc-7e555563aa211118.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libminiz_oxide-c8f13465f1a795b2.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libadler-ee5b5774583426df.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-14df174c91007922.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcfg_if-e8bfe52be756260a.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-6275035a459b3ada.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-b6892f3c52c68f01.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_core-f72b956e24d1de70.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-632ae0f28c5e55ff.rlib" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-e8b7e96e438f08f6.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-B~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-L" "~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/self-contained" "-o" "target/debug/deps/example-7fc4473584324aeb" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs"
  = note: rust-lld: error: undefined symbol: __start_linkme_BENCHMARKS
          >>> referenced by 85ysdi3oerszh3appz0f33ath
          >>>               target/debug/deps/example-7fc4473584324aeb.85ysdi3oerszh3appz0f33ath.rcgu.o:(example::BENCHMARKS::h81fa15da843ddfa5)
          >>> the encapsulation symbol needs to be retained under --gc-sections properly; consider -z nostart-stop-gc (see https://lld.llvm.org/ELF/start-stop-gc)

          rust-lld: error: undefined symbol: __stop_linkme_BENCHMARKS
          >>> referenced by 85ysdi3oerszh3appz0f33ath
          >>>               target/debug/deps/example-7fc4473584324aeb.85ysdi3oerszh3appz0f33ath.rcgu.o:(example::BENCHMARKS::h81fa15da843ddfa5)

          rust-lld: error: undefined symbol: __start_linkm2_BENCHMARKS
          >>> referenced by 85ysdi3oerszh3appz0f33ath
          >>>               target/debug/deps/example-7fc4473584324aeb.85ysdi3oerszh3appz0f33ath.rcgu.o:(example::BENCHMARKS::h81fa15da843ddfa5)
          >>> the encapsulation symbol needs to be retained under --gc-sections properly; consider -z nostart-stop-gc (see https://lld.llvm.org/ELF/start-stop-gc)

          rust-lld: error: undefined symbol: __stop_linkm2_BENCHMARKS
          >>> referenced by 85ysdi3oerszh3appz0f33ath
          >>>               target/debug/deps/example-7fc4473584324aeb.85ysdi3oerszh3appz0f33ath.rcgu.o:(example::BENCHMARKS::h81fa15da843ddfa5)
          collect2: error: ld returned 1 exit status
```