### PR TITLE
Unbreak platform support table in crate-level rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! # Platform support
 //!
 //! | Component | Linux | macOS | Windows | FreeBSD | OpenBSD | illumos | Other...<sup>†</sup> |
-//! |:---|:---:|:---:|:---:|:---:|:---:|:---:|
+//! |:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 //! | Distributed slice | 💚 | 💚 | 💚 | 💚 | 💚 | 💚 | |
 //!
 //! <br>***<sup>†</sup>*** We welcome PRs adding support for any platforms not


### PR DESCRIPTION
Closes #96.