### PR TITLE
Support WASM `std` targets.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ used_linker = ["linkme-impl/used_linker"]
 [dependencies]
 linkme-impl = { version = "=0.3.31", path = "impl" }
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+once_cell = "1.20.2"
+
+
 [dev-dependencies]
 once_cell = "1.16"
 rustversion = "1.0"

--- a/WASM.md
+++ b/WASM.md
@@ -1,0 +1,9 @@
+# WASM Support
+
+To support WASM, two requirements are needed: `std`, and a custom linker. 
+The custom linker must do the following:
+For each `import` module starting with `@@linkme`, rewrite its functions as follows:
+Find all `export`s whose name starts with the `import`'s module. The number of them
+should be the result of the `_len` function.
+The `_init` function should call all of the exports in any order by calling each
+with the output of the previous (if the first, the argument), then returning the output of the last.

--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -121,14 +121,13 @@ pub fn expand(input: TokenStream) -> TokenStream {
         Some(Token![unsafe](call_site))
     };
 
-    let (unsafe_attr, link_section_attr, wasm_import_attr, unsafe_attr_2) =
+    let (unsafe_attr, link_section_attr, wasm_import_attr) =
         if cfg!(no_unsafe_attributes) {
             // #[cfg_attr(all(), link_section = ...)]
             (
                 Ident::new("cfg_attr", call_site),
                 quote!(all(), link_section),
                 quote!(all(), wasm_import_module),
-                quote!(),
             )
         } else {
             // #[unsafe(link_section = ...)]
@@ -136,7 +135,6 @@ pub fn expand(input: TokenStream) -> TokenStream {
                 Ident::new("unsafe", call_site),
                 quote!(link_section),
                 quote!(wasm_import_module),
-                quote!(unsafe),
             )
         };
 
@@ -146,7 +144,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
             #[cfg(target_family = "wasm")]
             {
                 #[#unsafe_attr(#wasm_import_attr = #xname)]
-                #unsafe_attr_2 extern "C"{
+                #unsafe_extern extern "C"{
                     fn _init(a: *mut <#ty as #linkme_path::__private::Slice>::Element) -> *mut <#ty as #linkme_path::__private::Slice>::Element;
                     fn _len() -> usize;
                 }

--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -142,8 +142,9 @@ pub fn expand(input: TokenStream) -> TokenStream {
                     fn _init(a: *mut <#ty as #linkme_path::__private::Slice>::Element) -> *mut <#ty as #linkme_path::__private::Slice>::Element;
                     fn _len() -> usize;
                 }
+                static lazy: #linkme_path::__private::std::sync::OnceLock<#linkme_path::__private::StaticPtr<<#ty as #linkme_path::__private::Slice>::Element>> = #linkme_path::__private::std::sync::OnceLock::new();
                 unsafe{
-                    #linkme_path::DistributedSlice::private_new(#name,_init,_len)
+                    #linkme_path::DistributedSlice::private_new(#name,_init,_len,&lazy)
                 }
             }
             #[cfg(not(target_family = "wasm"))]

--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -121,17 +121,24 @@ pub fn expand(input: TokenStream) -> TokenStream {
         Some(Token![unsafe](call_site))
     };
 
-    let (unsafe_attr, link_section_attr, wasm_import_attr) = if cfg!(no_unsafe_attributes) {
-        // #[cfg_attr(all(), link_section = ...)]
-        (
-            Ident::new("cfg_attr", call_site),
-            quote!(all(), link_section),
-            quote!(all(), wasm_import_module)
-        )
-    } else {
-        // #[unsafe(link_section = ...)]
-        (Ident::new("unsafe", call_site), quote!(link_section), quote!(wasm_import_module))
-    };
+    let (unsafe_attr, link_section_attr, wasm_import_attr, unsafe_attr_2) =
+        if cfg!(no_unsafe_attributes) {
+            // #[cfg_attr(all(), link_section = ...)]
+            (
+                Ident::new("cfg_attr", call_site),
+                quote!(all(), link_section),
+                quote!(all(), wasm_import_module),
+                quote!(),
+            )
+        } else {
+            // #[unsafe(link_section = ...)]
+            (
+                Ident::new("unsafe", call_site),
+                quote!(link_section),
+                quote!(wasm_import_module),
+                quote!(unsafe),
+            )
+        };
 
     quote! {
         #(#attrs)*
@@ -139,7 +146,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
             #[cfg(target_family = "wasm")]
             {
                 #[#unsafe_attr(#wasm_import_attr = #xname)]
-                #unsafe_attr extern "C"{
+                #unsafe_attr_2 extern "C"{
                     fn _init(a: *mut <#ty as #linkme_path::__private::Slice>::Element) -> *mut <#ty as #linkme_path::__private::Slice>::Element;
                     fn _len() -> usize;
                 }

--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -121,15 +121,16 @@ pub fn expand(input: TokenStream) -> TokenStream {
         Some(Token![unsafe](call_site))
     };
 
-    let (unsafe_attr, link_section_attr) = if cfg!(no_unsafe_attributes) {
+    let (unsafe_attr, link_section_attr, wasm_import_attr) = if cfg!(no_unsafe_attributes) {
         // #[cfg_attr(all(), link_section = ...)]
         (
             Ident::new("cfg_attr", call_site),
             quote!(all(), link_section),
+            quote!(all(), wasm_import_module)
         )
     } else {
         // #[unsafe(link_section = ...)]
-        (Ident::new("unsafe", call_site), quote!(link_section))
+        (Ident::new("unsafe", call_site), quote!(link_section), quote!(wasm_import_module))
     };
 
     quote! {
@@ -137,7 +138,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
         #vis static #ident: #linkme_path::DistributedSlice<#ty> = {
             #[cfg(target_family = "wasm")]
             {
-                #[#unsafe_attr(wasm_import_module = #xname)]
+                #[#unsafe_attr(#wasm_import_attr = #xname)]
                 #unsafe_attr extern "C"{
                     fn _init(a: *mut <#ty as #linkme_path::__private::Slice>::Element) -> *mut <#ty as #linkme_path::__private::Slice>::Element;
                     fn _len() -> usize;

--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -148,7 +148,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
                     fn _init(a: *mut <#ty as #linkme_path::__private::Slice>::Element) -> *mut <#ty as #linkme_path::__private::Slice>::Element;
                     fn _len() -> usize;
                 }
-                static lazy: #linkme_path::__private::std::sync::OnceLock<#linkme_path::__private::StaticPtr<<#ty as #linkme_path::__private::Slice>::Element>> = #linkme_path::__private::std::sync::OnceLock::new();
+                static lazy: #linkme_path::__private::once_cell::sync::OnceCell<#linkme_path::__private::StaticPtr<<#ty as #linkme_path::__private::Slice>::Element>> = #linkme_path::__private::std::sync::OnceLock::new();
                 unsafe{
                     #linkme_path::DistributedSlice::private_new(#name,_init,_len,&lazy)
                 }

--- a/impl/src/element.rs
+++ b/impl/src/element.rs
@@ -231,7 +231,7 @@ fn do_expand(path: Path, pos: Option<usize>, input: Element) -> TokenStream {
                 #![linkme_macro = #path]
                 #![linkme_sort_key = concat!(#uid,#(#sort_key),*)]
             #(#attrs)*
-            #vis extern "C" unsafe fn #ident(a: *mut #ty) -> *mut #ty{
+            #vis  unsafe extern "C" fn #ident(a: *mut #ty) -> *mut #ty{
                 #[allow(clippy::no_effect_underscore_binding)]
                 unsafe fn __typecheck(_: #linkme_path::__private::Void) {
                     #[allow(clippy::ref_option_ref)]

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -148,8 +148,8 @@ pub struct DistributedSlice<T: ?Sized + Slice> {
     #[cfg(target_family = "wasm")]
     len: unsafe fn() -> usize,
 }
-
-struct StaticPtr<T> {
+#[doc(hidden)]
+pub struct StaticPtr<T> {
     ptr: *const T,
 }
 
@@ -172,12 +172,13 @@ impl<T> DistributedSlice<[T]> {
         name: &'static str,
         init: unsafe fn(*mut T::Element) -> *mut T::Element,
         len: unsafe fn() -> usize,
+        lazy: &'static ::std::sync::OnceLock<StaticPtr<T::Element>>,
     ) -> Self {
         DistributedSlice {
             name,
             init,
             len,
-            lazy: ::std::boxed::Box::leak(::std::boxed::Box::new(Default::default())),
+            lazy,
         }
     }
     #[doc(hidden)]

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -1,4 +1,6 @@
+#[allow(unused_imports)]
 use core::alloc::Layout;
+#[allow(unused_imports)]
 use core::cell::UnsafeCell;
 use core::fmt::{self, Debug};
 use core::hint;

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -142,7 +142,7 @@ pub struct DistributedSlice<T: ?Sized + Slice> {
     #[cfg(not(target_family = "wasm"))]
     dupcheck_stop: StaticPtr<usize>,
     #[cfg(target_family = "wasm")]
-    lazy: ::std::sync::OnceLock<StaticPtr<T::Element>>,
+    lazy: &'static ::std::sync::OnceLock<StaticPtr<T::Element>>,
     #[cfg(target_family = "wasm")]
     init: unsafe fn(*mut T::Element) -> *mut T::Element,
     #[cfg(target_family = "wasm")]
@@ -177,7 +177,7 @@ impl<T> DistributedSlice<[T]> {
             name,
             init,
             len,
-            lazy: Default::default(),
+            lazy: ::std::boxed::Box::leak(::std::boxed::Box::new(Default::default())),
         }
     }
     #[doc(hidden)]

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -144,7 +144,7 @@ pub struct DistributedSlice<T: ?Sized + Slice> {
     #[cfg(not(target_family = "wasm"))]
     dupcheck_stop: StaticPtr<usize>,
     #[cfg(target_family = "wasm")]
-    lazy: &'static ::std::sync::OnceLock<StaticPtr<T::Element>>,
+    lazy: &'static ::once_cell::sync::OnceCell<StaticPtr<T::Element>>,
     #[cfg(target_family = "wasm")]
     init: unsafe fn(*mut T::Element) -> *mut T::Element,
     #[cfg(target_family = "wasm")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,9 @@
     clippy::unused_self
 )]
 
+#[cfg(target_family = "wasm")]
+extern crate std;
+
 mod distributed_slice;
 
 // Not public API.

--- a/src/private.rs
+++ b/src/private.rs
@@ -7,6 +7,10 @@ pub use core::primitive::usize;
 #[doc(hidden)]
 pub use core::ptr;
 
+#[cfg(target_family = "wasm")]
+#[doc(hidden)]
+pub use std;
+
 #[doc(hidden)]
 pub trait Slice {
     type Element;

--- a/src/private.rs
+++ b/src/private.rs
@@ -22,3 +22,7 @@ impl<T> Slice for [T] {
 
 #[doc(hidden)]
 pub enum Void {}
+
+
+#[doc(hidden)]
+pub use crate::distributed_slice::StaticPtr;

--- a/src/private.rs
+++ b/src/private.rs
@@ -11,6 +11,10 @@ pub use core::ptr;
 #[doc(hidden)]
 pub use std;
 
+#[cfg(target_family = "wasm")]
+#[doc(hidden)]
+pub use once_cell;
+
 #[doc(hidden)]
 pub trait Slice {
     type Element;


### PR DESCRIPTION
This PR adds (currently untested) WASM `std` target support, which rely on an external linker, specified in `WASM.md`.