### PR TITLE
Restore use of lld in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, nightly-2025-03-08, nightly-2025-03-09, beta, stable, 1.82.0, 1.70.0]
+        rust: [nightly, beta, stable, 1.82.0, 1.70.0]
         os: [ubuntu]
         include:
           - name: macOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.82.0, 1.70.0]
+        rust: [nightly, nightly-2025-03-08, nightly-2025-03-09, beta, stable, 1.82.0, 1.70.0]
         os: [ubuntu]
         include:
           - name: macOS
@@ -48,10 +48,6 @@ jobs:
         shell: bash
       - name: Enable type layout randomization
         run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
-        if: matrix.rust == 'nightly'
-        shell: bash
-      - name: Disable rust-lld
-        run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
         if: matrix.rust == 'nightly'
         shell: bash
       - name: Ignore Windows linker warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,12 @@ jobs:
       matrix:
         rust: [nightly, beta, stable, 1.82.0, 1.70.0]
         os: [ubuntu]
+        linker: ['']
         include:
+          - name: Gold linker
+            os: ubuntu
+            rust: nightly
+            linker: gold
           - name: macOS
             os: macos
             rust: nightly
@@ -49,6 +54,10 @@ jobs:
       - name: Enable type layout randomization
         run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
         if: matrix.rust == 'nightly'
+        shell: bash
+      - name: Select non-default linker
+        run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zlinker-features=-lld -Clink-arg=-fuse-ld=${{matrix.linker}} >> $GITHUB_ENV
+        if: matrix.linker
         shell: bash
       - name: Ignore Windows linker warning
         run: echo RUSTFLAGS=${RUSTFLAGS}\ -Alinker_messages >> $GITHUB_ENV


### PR DESCRIPTION
Since nightly-2025-03-09, which contains https://github.com/rust-lang/rust/pull/137685, lld works again.