### PR TITLE
Raise required compiler to Rust 1.66

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,14 @@ jobs:
         working-directory: tests/cortex
 
   msrv:
-    name: Rust 1.62.0
+    name: Rust 1.65.0
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@1.62.0
+      - uses: dtolnay/rust-toolchain@1.65.0
       - run: cargo check
 
   minimal:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,14 @@ jobs:
         working-directory: tests/cortex
 
   msrv:
-    name: Rust 1.65.0
+    name: Rust 1.66.0
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@1.65.0
+      - uses: dtolnay/rust-toolchain@1.66.0
       - run: cargo check
 
   minimal:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 keywords = ["linkage"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/linkme"
-rust-version = "1.62"
+rust-version = "1.65"
 
 [[test]]
 name = "module_2015"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 keywords = ["linkage"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/linkme"
-rust-version = "1.65"
+rust-version = "1.66"
 
 [[test]]
 name = "module_2015"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ here.
 linkme = "0.3"
 ```
 
-*Supports rustc 1.62+*
+*Supports rustc 1.65+*
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ here.
 linkme = "0.3"
 ```
 
-*Supports rustc 1.65+*
+*Supports rustc 1.66+*
 
 <br>
 

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/linkme"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/linkme"
-rust-version = "1.62"
+rust-version = "1.65"
 
 [lib]
 proc-macro = true

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/linkme"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/linkme"
-rust-version = "1.65"
+rust-version = "1.66"
 
 [lib]
 proc-macro = true

--- a/impl/build.rs
+++ b/impl/build.rs
@@ -5,9 +5,8 @@ use std::str;
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
-    let rustc = match rustc_minor_version() {
-        Some(rustc) => rustc,
-        None => return,
+    let Some(rustc) = rustc_minor_version() else {
+        return;
     };
 
     if rustc >= 80 {

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -229,11 +229,10 @@ impl<T> DistributedSlice<[T]> {
         let start = self.section_start.ptr;
         let stop = self.section_stop.ptr;
         let byte_offset = stop as usize - start as usize;
-        let len = match byte_offset.checked_div(stride) {
-            Some(len) => len,
+        let Some(len) = byte_offset.checked_div(stride) else {
             // The #[distributed_slice] call checks `size_of::<T>() > 0` before
             // using the unsafe `private_new`.
-            None => unsafe { hint::unreachable_unchecked() },
+            unsafe { hint::unreachable_unchecked() }
         };
 
         // On Windows, the implementation involves growing a &[T; 0] to


### PR DESCRIPTION
```console
warning: current MSRV (Minimum Supported Rust Version) is `1.62.0` but this item is stable since `1.66.0`
   --> src/distributed_slice.rs:244:21
    |
244 |         let start = hint::black_box(start);
    |                     ^^^^^^^^^^^^^^^
    |
    = note: you may want to conditionally increase the MSRV considered by Clippy using the `clippy::msrv` attribute
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv
    = note: `-W clippy::incompatible-msrv` implied by `-W clippy::all`
    = help: to override `-W clippy::all` add `#[allow(clippy::incompatible_msrv)]`
```