### PR TITLE
Fix Windows/UEFI handling for non-ZST sentinels in distributed slices

### DIFF
--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -172,21 +172,24 @@ pub fn expand(input: TokenStream) -> TokenStream {
                 static DUPCHECK_STOP: ();
             }
 
+            // On Windows/UEFI, use non-ZST sentinels because some codegen
+            // backends emit non-zero bytes for ZST statics in custom PE/COFF
+            // sections, which corrupts section boundary and dupcheck arithmetic.
             #[cfg(any(target_os = "uefi", target_os = "windows"))]
             #[#unsafe_attr(#link_section_attr = #windows_section_start)]
-            static LINKME_START: [<#ty as #linkme_path::#private::Slice>::Element; 0] = [];
+            static LINKME_START: ::core::mem::MaybeUninit<<#ty as #linkme_path::#private::Slice>::Element> = ::core::mem::MaybeUninit::uninit();
 
             #[cfg(any(target_os = "uefi", target_os = "windows"))]
             #[#unsafe_attr(#link_section_attr = #windows_section_stop)]
-            static LINKME_STOP: [<#ty as #linkme_path::#private::Slice>::Element; 0] = [];
+            static LINKME_STOP: ::core::mem::MaybeUninit<<#ty as #linkme_path::#private::Slice>::Element> = ::core::mem::MaybeUninit::uninit();
 
             #[cfg(any(target_os = "uefi", target_os = "windows"))]
             #[#unsafe_attr(#link_section_attr = #windows_dupcheck_start)]
-            static DUPCHECK_START: () = ();
+            static DUPCHECK_START: #linkme_path::#private::isize = 0;
 
             #[cfg(any(target_os = "uefi", target_os = "windows"))]
             #[#unsafe_attr(#link_section_attr = #windows_dupcheck_stop)]
-            static DUPCHECK_STOP: () = ();
+            static DUPCHECK_STOP: #linkme_path::#private::isize = 0;
 
             #used
             #[cfg(any(
@@ -232,10 +235,10 @@ pub fn expand(input: TokenStream) -> TokenStream {
             unsafe {
                 #linkme_path::DistributedSlice::private_new(
                     #name,
-                    #linkme_path::#private::ptr::addr_of!(LINKME_START),
-                    #linkme_path::#private::ptr::addr_of!(LINKME_STOP),
-                    #linkme_path::#private::ptr::addr_of!(DUPCHECK_START),
-                    #linkme_path::#private::ptr::addr_of!(DUPCHECK_STOP),
+                    #linkme_path::#private::ptr::addr_of!(LINKME_START).cast(),
+                    #linkme_path::#private::ptr::addr_of!(LINKME_STOP).cast(),
+                    #linkme_path::#private::ptr::addr_of!(DUPCHECK_START).cast(),
+                    #linkme_path::#private::ptr::addr_of!(DUPCHECK_STOP).cast(),
                 )
             }
         };

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -229,12 +229,22 @@ impl<T> DistributedSlice<[T]> {
     /// }
     /// ```
     pub fn static_slice(self) -> &'static [T] {
-        if self.dupcheck_start.ptr.wrapping_add(1) < self.dupcheck_stop.ptr {
+        // On Windows/UEFI, sentinels are non-ZST (MaybeUninit<T> and isize)
+        // so dupcheck and slice boundary arithmetic must account for their size.
+        #[cfg(any(target_os = "uefi", target_os = "windows"))]
+        let is_duplicate = self.dupcheck_start.ptr.wrapping_add(2) < self.dupcheck_stop.ptr;
+        #[cfg(not(any(target_os = "uefi", target_os = "windows")))]
+        let is_duplicate = self.dupcheck_start.ptr.wrapping_add(1) < self.dupcheck_stop.ptr;
+        if is_duplicate {
             panic!("duplicate #[distributed_slice] with name \"{}\"", self.name);
         }
 
         let start = self.section_start.ptr;
         let stop = self.section_stop.ptr;
+
+        // Skip the non-ZST start sentinel on Windows/UEFI.
+        #[cfg(any(target_os = "uefi", target_os = "windows"))]
+        let start = unsafe { start.add(1) };
         let byte_offset = stop as usize - start as usize;
         let len = byte_offset / self.stride;
 


### PR DESCRIPTION
On Windows (and UEFI), `distributed_slice` relies on ZST statics (`()` and `[T; 0]`) occupying exactly 0 bytes in PE/COFF grouped sections, but this is not guaranteed by the language and breaks with some codegen backends (#125). ZST sections are also fragile in other ways: rust-lld crashes on empty slices (#114) and MinGW's linker garbage-collects them (#25).

This PR replaces the ZST sentinels with non-ZST types of known size -- `MaybeUninit<T>` for slice boundaries and `isize` for dupcheck boundaries -- then adjusts the runtime arithmetic to account for the sentinel bytes: `wrapping_add(2)` for dupcheck and `start.add(1)` to skip the start sentinel.

All changes are behind `cfg(windows/uefi)` and do not affect other platforms.

Closes #125