### PR TITLE
Add distributed slice support on wasm32 targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,24 @@ jobs:
           RUSTFLAGS: -C link-arg=-Tlink.x -D warnings
         working-directory: tests/cortex
 
+  wasm:
+    name: WebAssembly
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      matrix:
+        target:
+          - wasm32-unknown-emscripten
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          target: ${{matrix.target}}
+      - run: cargo check --target ${{matrix.target}} -p linkme --tests
+
   msrv:
     name: Rust 1.71.0
     needs: pre_ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "linkme"
 version = "0.3.36"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
-categories = ["development-tools::build-utils", "development-tools::procedural-macro-helpers", "no-std", "no-std::no-alloc"]
+categories = ["development-tools::build-utils", "development-tools::procedural-macro-helpers", "no-std"]
 description = "Safe cross-platform linker shenanigans"
 documentation = "https://docs.rs/linkme"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-linkme-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" height="20">](https://docs.rs/linkme)
 [<img alt="build status" src="https://img.shields.io/github/actions/workflow/status/dtolnay/linkme/ci.yml?branch=master&style=for-the-badge" height="20">](https://github.com/dtolnay/linkme/actions?query=branch%3Amaster)
 
-| Component | Linux | macOS | Windows | FreeBSD | OpenBSD | illumos | Other...<sup>†</sup> |
-|:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| [Distributed slice] | 💚 | 💚 | 💚 | 💚 | 💚 | 💚 | |
+| Component | Linux | wasm32 | macOS | Windows | FreeBSD | OpenBSD | illumos | Other...<sup>†</sup> |
+|:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| [Distributed slice] | 💚 | 💚 | 💚 | 💚 | 💚 | 💚 | 💚 | |
 
 <b><sup>†</sup></b> We welcome PRs adding support for any platforms not listed
 here.
@@ -23,14 +23,20 @@ linkme = "0.3"
 
 # Distributed slice
 
-A distributed slice is a collection of static elements that are gathered into a
-contiguous section of the binary by the linker. Slice elements may be defined
-individually from anywhere in the dependency graph of the final binary.
+A distributed slice is a collection of static elements. On most platforms they
+are gathered into a contiguous section of the binary by the linker; on wasm32
+targets, startup constructors register elements and the slice is materialized
+on first access. Slice elements may be defined individually from anywhere in the
+dependency graph of the final binary.
 
 The implementation is based on `link_section` attributes and platform-specific
-linker support. It does not involve life-before-main or any other runtime
-initialization on any platform. This is a zero-cost safe abstraction that
-operates entirely during compilation and linking.
+linker support. Except on wasm32, it does not involve life-before-main or any
+other runtime initialization. On wasm32, startup constructors are used to
+collect elements because wasm custom sections cannot carry the relocations
+needed by arbitrary Rust statics. On `wasm32-unknown-emscripten` and WASI
+targets the runtime invokes these constructors automatically; on
+`wasm32-unknown-unknown` the embedder must call `__wasm_call_ctors` explicitly
+(wasm-bindgen handles this transparently).
 
 ### Declaration
 

--- a/impl/src/declaration.rs
+++ b/impl/src/declaration.rs
@@ -112,6 +112,8 @@ pub fn expand(input: TokenStream) -> TokenStream {
     let call_site = Span::call_site();
     let link_section_macro_str = format!("_linkme_macro_{}", ident);
     let link_section_macro = Ident::new(&link_section_macro_str, call_site);
+    let registry_str = format!("_LINKME_REGISTRY_{}", ident);
+    let registry = Ident::new(&registry_str, call_site);
 
     let unsafe_extern = if cfg!(no_unsafe_extern_blocks) {
         None
@@ -131,6 +133,12 @@ pub fn expand(input: TokenStream) -> TokenStream {
     };
 
     quote! {
+        #[cfg(target_arch = "wasm32")]
+        #[doc(hidden)]
+        static #registry: #linkme_path::#private::WasmRegistry<
+            <#ty as #linkme_path::#private::Slice>::Element,
+        > = #linkme_path::#private::WasmRegistry::new();
+
         #(#attrs)*
         #vis static #ident: #linkme_path::DistributedSlice<#ty> = {
             #[cfg(any(
@@ -217,6 +225,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
             static DUPCHECK: #linkme_path::#private::isize = 1;
 
             #[cfg(not(any(
+                target_arch = "wasm32",
                 target_os = "none",
                 target_os = "linux",
                 target_os = "macos",
@@ -233,6 +242,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
             )))]
             #unsupported_platform
 
+            #[cfg(not(target_arch = "wasm32"))]
             unsafe {
                 #linkme_path::DistributedSlice::private_new(
                     #name,
@@ -246,6 +256,14 @@ pub fn expand(input: TokenStream) -> TokenStream {
                         .cast::<#linkme_path::#private::isize>(),
                 )
             }
+
+            #[cfg(target_arch = "wasm32")]
+            unsafe {
+                #linkme_path::DistributedSlice::private_new_wasm(
+                    #name,
+                    #linkme_path::#private::ptr::addr_of!(#registry),
+                )
+            }
         };
 
         #[doc(hidden)]
@@ -254,7 +272,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
             (
                 #![linkme_macro = $macro:path]
                 #![linkme_sort_key = $key:tt]
-                $item:item
+                $($item:tt)*
             ) => {
                 $macro ! {
                     #![linkme_linux_section = concat!(#linux_section, $key)]
@@ -262,12 +280,14 @@ pub fn expand(input: TokenStream) -> TokenStream {
                     #![linkme_windows_section = concat!(#windows_section, $key)]
                     #![linkme_illumos_section = concat!(#illumos_section, $key)]
                     #![linkme_bsd_section = concat!(#bsd_section, $key)]
-                    $item
+                    #![linkme_sort_key = $key]
+                    #![linkme_slice = $macro]
+                    $($item)*
                 }
             };
             (
                 #![linkme_macro = $macro:path]
-                $item:item
+                $($item:tt)*
             ) => {
                 $macro ! {
                     #![linkme_linux_section = #linux_section]
@@ -275,7 +295,9 @@ pub fn expand(input: TokenStream) -> TokenStream {
                     #![linkme_windows_section = #windows_section]
                     #![linkme_illumos_section = #illumos_section]
                     #![linkme_bsd_section = #bsd_section]
-                    $item
+                    #![linkme_sort_key = ""]
+                    #![linkme_slice = $macro]
+                    $($item)*
                 }
             };
             (
@@ -284,7 +306,10 @@ pub fn expand(input: TokenStream) -> TokenStream {
                 #![linkme_windows_section = $windows_section:expr]
                 #![linkme_illumos_section = $illumos_section:expr]
                 #![linkme_bsd_section = $bsd_section:expr]
-                $item:item
+                #![linkme_sort_key = $sort_key:tt]
+                #![linkme_slice = $slice:path]
+                $(#[$attr:meta])*
+                $vis:vis static $element:ident : $ty:ty = $expr:expr;
             ) => {
                 #used
                 #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia", target_os = "psp"), #unsafe_attr(#link_section_attr = $linux_section))]
@@ -292,7 +317,30 @@ pub fn expand(input: TokenStream) -> TokenStream {
                 #[cfg_attr(any(target_os = "uefi", target_os = "windows"), #unsafe_attr(#link_section_attr = $windows_section))]
                 #[cfg_attr(target_os = "illumos", #unsafe_attr(#link_section_attr = $illumos_section))]
                 #[cfg_attr(any(target_os = "freebsd", target_os = "openbsd"), #unsafe_attr(#link_section_attr = $bsd_section))]
-                $item
+                $(#[$attr])*
+                $vis static $element : $ty = $expr;
+
+                #[cfg(target_arch = "wasm32")]
+                const _: () = {
+                    static __NODE: #linkme_path::#private::WasmEntryNode<$ty> =
+                        #linkme_path::#private::WasmEntryNode::new(
+                            $sort_key,
+                            #linkme_path::#private::ptr::addr_of!($element),
+                        );
+
+                    extern "C" fn __linkme_init() {
+                        unsafe {
+                            #linkme_path::DistributedSlice::private_wasm_register(
+                                $slice,
+                                &__NODE,
+                            );
+                        }
+                    }
+
+                    #used
+                    #[#unsafe_attr(#link_section_attr = ".init_array")]
+                    static __LINKME_INIT_ARRAY: extern "C" fn() = __linkme_init;
+                };
             };
         }
 

--- a/src/distributed_slice.rs
+++ b/src/distributed_slice.rs
@@ -7,13 +7,25 @@ use core::num::NonZeroUsize;
 use core::ops::Deref;
 use core::slice;
 
-/// Collection of static elements that are gathered into a contiguous section of
-/// the binary by the linker.
+/// Collection of static elements.
+///
+/// On most platforms they are gathered into a contiguous section of the binary
+/// by the linker. On wasm32 targets, startup constructors register elements
+/// and the slice is materialized on first access.
 ///
 /// The implementation is based on `link_section` attributes and
-/// platform-specific linker support. It does not involve life-before-main or
-/// any other runtime initialization on any platform. This is a zero-cost safe
-/// abstraction that operates entirely during compilation and linking.
+/// platform-specific linker support. Except on wasm32, it does not involve
+/// life-before-main or any other runtime initialization. On wasm32, startup
+/// constructors are used to collect elements because wasm custom sections
+/// cannot carry the relocations needed by arbitrary Rust statics.
+///
+/// On `wasm32-unknown-emscripten` and WASI targets the runtime invokes
+/// `.init_array` constructors automatically before `main`. On
+/// `wasm32-unknown-unknown` the embedder must call `__wasm_call_ctors`
+/// explicitly; wasm-bindgen handles this transparently.
+///
+/// Duplicate slice detection is performed via the linker on supported native
+/// targets and is skipped on wasm32.
 ///
 /// ## Declaration
 ///
@@ -130,6 +142,7 @@ use core::slice;
 ///     /* ... */
 /// }
 /// ```
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub struct DistributedSlice<T: ?Sized + Slice> {
     name: &'static str,
     stride: NonZeroUsize,
@@ -137,6 +150,8 @@ pub struct DistributedSlice<T: ?Sized + Slice> {
     section_stop: StaticPtr<T::Element>,
     dupcheck_start: StaticPtr<isize>,
     dupcheck_stop: StaticPtr<isize>,
+    #[cfg(target_arch = "wasm32")]
+    wasm_registry: StaticPtr<crate::private::WasmRegistry<T::Element>>,
 }
 
 struct StaticPtr<T> {
@@ -178,6 +193,40 @@ impl<T> DistributedSlice<[T]> {
                 ptr: dupcheck_start,
             },
             dupcheck_stop: StaticPtr { ptr: dupcheck_stop },
+            #[cfg(target_arch = "wasm32")]
+            wasm_registry: StaticPtr {
+                ptr: core::ptr::null(),
+            },
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[doc(hidden)]
+    #[track_caller]
+    pub const unsafe fn private_new_wasm(
+        name: &'static str,
+        registry: *const crate::private::WasmRegistry<T>,
+    ) -> Self {
+        let Some(stride) = NonZeroUsize::new(mem::size_of::<T>()) else {
+            panic!("#[distributed_slice] requires that the slice element type has nonzero size");
+        };
+
+        DistributedSlice {
+            name,
+            stride,
+            section_start: StaticPtr {
+                ptr: core::ptr::null(),
+            },
+            section_stop: StaticPtr {
+                ptr: core::ptr::null(),
+            },
+            dupcheck_start: StaticPtr {
+                ptr: core::ptr::null(),
+            },
+            dupcheck_stop: StaticPtr {
+                ptr: core::ptr::null(),
+            },
+            wasm_registry: StaticPtr { ptr: registry },
         }
     }
 
@@ -185,6 +234,17 @@ impl<T> DistributedSlice<[T]> {
     #[inline]
     pub unsafe fn private_typecheck(self, get: fn() -> &'static T) {
         let _ = get;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[doc(hidden)]
+    pub unsafe fn private_wasm_register(self, node: &'static crate::private::WasmEntryNode<T>)
+    where
+        T: 'static,
+    {
+        unsafe {
+            (*self.wasm_registry.ptr).register(node);
+        }
     }
 
     /// Retrieve a contiguous slice containing all the elements linked into this
@@ -195,6 +255,12 @@ impl<T> DistributedSlice<[T]> {
     /// through the power of `Deref`. In particular, iteration and indexing and
     /// method calls can all happen directly on the static without calling
     /// `static_slice()`.
+    ///
+    /// On wasm32 targets, the slice is materialized on the first call from
+    /// elements registered by startup constructors, then cached for all
+    /// subsequent calls. The returned slice is a byte copy of the original
+    /// element statics; for elements with interior mutability or that require
+    /// address identity, use [`iter_refs()`][Self::iter_refs] instead.
     ///
     /// ```no_run
     /// # #![cfg_attr(feature = "used_linker", feature(used_with_arg))]
@@ -223,27 +289,61 @@ impl<T> DistributedSlice<[T]> {
     /// }
     /// ```
     pub fn static_slice(self) -> &'static [T] {
-        // On Windows/UEFI, boundary elements are non-ZST (MaybeUninit<T> and
-        // isize) so dupcheck and slice boundary arithmetic must account for
-        // their size.
-        let skip = usize::from(cfg!(any(target_os = "uefi", target_os = "windows")));
-        if self.dupcheck_start.ptr.wrapping_add(skip + 1) < self.dupcheck_stop.ptr {
-            panic!("duplicate #[distributed_slice] with name \"{}\"", self.name);
+        #[cfg(target_arch = "wasm32")]
+        {
+            unsafe { (*self.wasm_registry.ptr).static_slice() }
         }
 
-        let start = unsafe { self.section_start.ptr.add(skip) };
-        let stop = self.section_stop.ptr;
-        let byte_offset = stop as usize - start as usize;
-        let len = byte_offset / self.stride;
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            // On Windows/UEFI, boundary elements are non-ZST (MaybeUninit<T>
+            // and isize) so dupcheck and slice boundary arithmetic must
+            // account for their size.
+            let skip = usize::from(cfg!(any(target_os = "uefi", target_os = "windows")));
+            if self.dupcheck_start.ptr.wrapping_add(skip + 1) < self.dupcheck_stop.ptr {
+                panic!("duplicate #[distributed_slice] with name \"{}\"", self.name);
+            }
 
-        // On Windows, the implementation involves growing a &[T; 0] to
-        // encompass elements that we have asked the linker to place immediately
-        // after that location. The compiler sees this as going "out of bounds"
-        // based on provenance, so we must conceal what is going on.
-        #[cfg(any(target_os = "uefi", target_os = "windows"))]
-        let start = hint::black_box(start);
+            let start = unsafe { self.section_start.ptr.add(skip) };
+            let stop = self.section_stop.ptr;
+            let byte_offset = stop as usize - start as usize;
+            let len = byte_offset / self.stride;
 
-        unsafe { slice::from_raw_parts(start, len) }
+            // On Windows, the implementation involves growing a &[T; 0] to
+            // encompass elements that we have asked the linker to place
+            // immediately after that location. The compiler sees this as going
+            // "out of bounds" based on provenance, so we must conceal what is
+            // going on.
+            #[cfg(any(target_os = "uefi", target_os = "windows"))]
+            let start = hint::black_box(start);
+
+            unsafe { slice::from_raw_parts(start, len) }
+        }
+    }
+
+    /// Iterate over references to all registered elements at their original
+    /// static addresses, in declaration/sort-key order.
+    ///
+    /// On most platforms this is equivalent to `self.static_slice().iter()`,
+    /// because the linker section already holds the original element storage.
+    /// On wasm32 targets, `static_slice()` returns references into a fresh
+    /// byte-copy of the registered elements; `iter_refs()` returns references
+    /// to the original element statics, which matters when elements contain
+    /// interior mutability (`AtomicUsize`, `UnsafeCell`, etc.) or when pointer
+    /// identity with the declaring static must be preserved.
+    pub fn iter_refs(self) -> impl Iterator<Item = &'static T>
+    where
+        T: 'static,
+    {
+        #[cfg(target_arch = "wasm32")]
+        {
+            unsafe { (*self.wasm_registry.ptr).iter_refs() }
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.static_slice().iter()
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,9 @@
 //!
 //! # Platform support
 //!
-//! | Component | Linux | macOS | Windows | FreeBSD | OpenBSD | illumos | Other...<sup>†</sup> |
-//! |:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-//! | Distributed slice | 💚 | 💚 | 💚 | 💚 | 💚 | 💚 | |
+//! | Component | Linux | wasm32 | macOS | Windows | FreeBSD | OpenBSD | illumos | Other...<sup>†</sup> |
+//! |:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+//! | Distributed slice | 💚 | 💚 | 💚 | 💚 | 💚 | 💚 | 💚 | |
 //!
 //! <br>***<sup>†</sup>*** We welcome PRs adding support for any platforms not
 //! listed here.
@@ -23,10 +23,11 @@
 //!
 //! # Distributed slice
 //!
-//! A distributed slice is a collection of static elements that are gathered
-//! into a contiguous section of the binary by the linker. Slice elements may be
-//! defined individually from anywhere in the dependency graph of the final
-//! binary.
+//! A distributed slice is a collection of static elements. On most platforms
+//! they are gathered into a contiguous section of the binary by the linker. On
+//! wasm32 targets, startup constructors register elements and the slice is
+//! materialized on first access. Slice elements may be defined individually
+//! from anywhere in the dependency graph of the final binary.
 //!
 //! Refer to [`linkme::DistributedSlice`][DistributedSlice] for complete details
 //! of the API. The basic idea is as follows.
@@ -146,6 +147,9 @@
     clippy::must_use_candidate,
     clippy::unused_self
 )]
+
+#[cfg(target_arch = "wasm32")]
+extern crate alloc;
 
 mod distributed_slice;
 mod private;

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,7 +1,11 @@
+#[cfg(target_arch = "wasm32")]
+use alloc::vec::Vec;
 #[doc(hidden)]
 pub use core::primitive::isize;
 #[doc(hidden)]
 pub use core::ptr;
+#[cfg(target_arch = "wasm32")]
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
 
 #[doc(hidden)]
 pub trait Slice {
@@ -18,3 +22,223 @@ pub enum Void {}
 #[cfg(any(target_os = "uefi", target_os = "windows"))]
 #[doc(hidden)]
 pub type BoundaryElement<T> = core::mem::MaybeUninit<<T as Slice>::Element>;
+
+/// A node in the intrusive linked list used to collect elements on wasm32.
+///
+/// Each registered element has exactly one `WasmEntryNode` stored in a static,
+/// so registration never allocates.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+pub struct WasmEntryNode<T> {
+    sort_key: &'static str,
+    element: *const T,
+    next: AtomicPtr<WasmEntryNode<T>>,
+}
+
+#[cfg(target_arch = "wasm32")]
+unsafe impl<T> Send for WasmEntryNode<T> {}
+
+#[cfg(target_arch = "wasm32")]
+unsafe impl<T> Sync for WasmEntryNode<T> {}
+
+#[cfg(target_arch = "wasm32")]
+impl<T> WasmEntryNode<T> {
+    #[doc(hidden)]
+    pub const fn new(sort_key: &'static str, element: *const T) -> Self {
+        WasmEntryNode {
+            sort_key,
+            element,
+            next: AtomicPtr::new(core::ptr::null_mut()),
+        }
+    }
+}
+
+/// Per-slice registry that collects element nodes via `.init_array` constructors
+/// and materializes the slice on first access.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+pub struct WasmRegistry<T> {
+    head: AtomicPtr<WasmEntryNode<T>>,
+    finalized: AtomicBool,
+    sorted_ptr: AtomicPtr<*const WasmEntryNode<T>>,
+    sorted_len: AtomicUsize,
+    slice_ptr: AtomicPtr<T>,
+    slice_len: AtomicUsize,
+    finalize_lock: AtomicBool,
+    materialize_lock: AtomicBool,
+}
+
+#[cfg(target_arch = "wasm32")]
+unsafe impl<T> Sync for WasmRegistry<T> {}
+
+#[cfg(target_arch = "wasm32")]
+impl<T> WasmRegistry<T> {
+    #[doc(hidden)]
+    pub const fn new() -> Self {
+        WasmRegistry {
+            head: AtomicPtr::new(core::ptr::null_mut()),
+            finalized: AtomicBool::new(false),
+            sorted_ptr: AtomicPtr::new(core::ptr::null_mut()),
+            sorted_len: AtomicUsize::new(0),
+            slice_ptr: AtomicPtr::new(core::ptr::null_mut()),
+            slice_len: AtomicUsize::new(0),
+            finalize_lock: AtomicBool::new(false),
+            materialize_lock: AtomicBool::new(false),
+        }
+    }
+
+    /// Push `node` onto the head of the linked list.  Lock-free.
+    ///
+    /// # Safety
+    ///
+    /// Must be called before finalize() runs, i.e. during `.init_array`
+    /// constructor execution.
+    #[doc(hidden)]
+    pub unsafe fn register(&self, node: &'static WasmEntryNode<T>) {
+        debug_assert!(
+            !self.finalized.load(Ordering::Acquire),
+            "WasmRegistry::register called after finalization"
+        );
+        let node_ptr = node as *const WasmEntryNode<T> as *mut WasmEntryNode<T>;
+        let mut current = self.head.load(Ordering::Relaxed);
+        loop {
+            node.next.store(current, Ordering::Relaxed);
+            match self
+                .head
+                .compare_exchange_weak(current, node_ptr, Ordering::Release, Ordering::Relaxed)
+            {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<T: 'static> WasmRegistry<T> {
+    fn finalize(&'static self) -> &'static [*const WasmEntryNode<T>] {
+        if self.finalized.load(Ordering::Acquire) {
+            let ptr = self.sorted_ptr.load(Ordering::Acquire) as *const *const WasmEntryNode<T>;
+            let len = self.sorted_len.load(Ordering::Acquire);
+            return unsafe { core::slice::from_raw_parts(ptr, len) };
+        }
+
+        while self
+            .finalize_lock
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            core::hint::spin_loop();
+        }
+
+        if self.finalized.load(Ordering::Acquire) {
+            self.finalize_lock.store(false, Ordering::Release);
+            let ptr = self.sorted_ptr.load(Ordering::Acquire) as *const *const WasmEntryNode<T>;
+            let len = self.sorted_len.load(Ordering::Acquire);
+            return unsafe { core::slice::from_raw_parts(ptr, len) };
+        }
+
+        let mut nodes: Vec<*const WasmEntryNode<T>> = Vec::new();
+        let mut current = self.head.load(Ordering::Acquire) as *const WasmEntryNode<T>;
+        while !current.is_null() {
+            nodes.push(current);
+            current = unsafe { (*current).next.load(Ordering::Acquire) };
+        }
+
+        nodes.sort_by(|&a, &b| unsafe { (*a).sort_key.cmp((*b).sort_key) });
+
+        let leaked = Vec::leak(nodes);
+        let len = leaked.len();
+        let ptr = leaked.as_mut_ptr();
+
+        self.sorted_len.store(len, Ordering::Release);
+        self.sorted_ptr.store(ptr, Ordering::Release);
+        self.finalized.store(true, Ordering::Release);
+        self.finalize_lock.store(false, Ordering::Release);
+
+        unsafe { core::slice::from_raw_parts(ptr as *const *const WasmEntryNode<T>, len) }
+    }
+
+    /// Return a slice of all registered elements, byte-copied into a stable
+    /// `'static` allocation.  Idempotent; subsequent calls return the same slice.
+    ///
+    /// # Safety
+    ///
+    /// Must be called after all `.init_array` constructors have run.
+    #[doc(hidden)]
+    pub unsafe fn static_slice(&'static self) -> &'static [T] {
+        let existing = self.slice_ptr.load(Ordering::Acquire);
+        if !existing.is_null() {
+            let len = self.slice_len.load(Ordering::Acquire);
+            return unsafe { core::slice::from_raw_parts(existing, len) };
+        }
+
+        let nodes = self.finalize();
+
+        while self
+            .materialize_lock
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            core::hint::spin_loop();
+        }
+
+        let existing = self.slice_ptr.load(Ordering::Acquire);
+        if !existing.is_null() {
+            self.materialize_lock.store(false, Ordering::Release);
+            let len = self.slice_len.load(Ordering::Acquire);
+            return unsafe { core::slice::from_raw_parts(existing, len) };
+        }
+
+        let mut collected: Vec<T> = Vec::with_capacity(nodes.len());
+        for &node_ptr in nodes {
+            let out = unsafe { collected.as_mut_ptr().add(collected.len()) };
+            unsafe {
+                ptr::copy_nonoverlapping((*node_ptr).element, out, 1);
+                collected.set_len(collected.len() + 1);
+            }
+        }
+
+        let slice = Vec::leak(collected);
+        let data_ptr = slice.as_ptr() as *mut T;
+        let len = slice.len();
+
+        self.slice_len.store(len, Ordering::Release);
+        self.slice_ptr.store(data_ptr, Ordering::Release);
+        self.materialize_lock.store(false, Ordering::Release);
+
+        slice
+    }
+
+    /// Iterate over references to the original element statics in sorted order.
+    ///
+    /// Unlike `static_slice()`, this preserves the address of each element as
+    /// declared, which matters for elements containing interior mutability.
+    ///
+    /// # Safety
+    ///
+    /// Must be called after all `.init_array` constructors have run.
+    #[doc(hidden)]
+    pub unsafe fn iter_refs(&'static self) -> WasmRefIter<T> {
+        let nodes = self.finalize();
+        WasmRefIter {
+            inner: nodes.iter(),
+        }
+    }
+}
+
+/// Iterator over address-identical references to registered wasm32 elements.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+pub struct WasmRefIter<T: 'static> {
+    inner: core::slice::Iter<'static, *const WasmEntryNode<T>>,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<T: 'static> Iterator for WasmRefIter<T> {
+    type Item = &'static T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|&node_ptr| unsafe { &*(*node_ptr).element })
+    }
+}


### PR DESCRIPTION
Hello! Love `linkme` crate, and needed it to work with wasm/emscripten. I asked
an Claude/Codex to work on it. I am not familiar enough with linker stuff to review this PR myself, so I present this as, work that I would gladly improve, if given a review.

Thanks!

Closes #86

<details><summary>Details by AI</summary>
<p>



## Summary

- Distributed slice support on wasm32 (emscripten, wasi, unknown-unknown)
- Mechanism: lock-free intrusive list collected via `.init_array` ctors, materialized on first access
- New `DistributedSlice::iter_refs()` for callers that need element-address identity

## Why

wasm custom sections can't carry the relocations needed by arbitrary Rust statics, so the linker-section approach used on every other platform doesn't work. This PR adds an alternative collection mechanism gated to `target_arch = "wasm32"`.

## Implementation

- Per-slice `WasmRegistry<T>` holds a CAS-pushed intrusive linked list of `WasmEntryNode<T>` statics (one per element, stored alongside the element static — no heap allocation during ctor execution).
- Each element generates an `extern "C" fn` placed in `.init_array` that registers its node.
- `static_slice()` lazily materializes a sorted byte-copy on first access.
- `iter_refs()` returns references to the original element statics, preserving address identity (matters for elements containing `AtomicUsize` / `UnsafeCell` / etc.).
- Pure `core::sync::atomic` — no new dependencies.
- `extern crate alloc` gated to `target_arch = "wasm32"`; other targets remain `no_std` + no-alloc.

## Caveats (documented)

- On `wasm32-unknown-unknown` the embedder must invoke `__wasm_call_ctors`; wasm-bindgen handles this transparently.
- `static_slice()` byte-copies on wasm32; use `iter_refs()` for element-address identity.
- Duplicate-slice detection is skipped on wasm32 (registries are per-declaration so the linker-name-collision shape doesn't apply).

## Test plan

- [x] `cargo test -p linkme -p linkme-impl` (host) — 24 passed, 1 ignored, no regressions
- [x] `cargo check --target wasm32-unknown-emscripten -p linkme --tests` — clean
- [x] `cargo check --target wasm32-unknown-unknown -p linkme --tests` — clean
- [x] `cargo clippy -p linkme --tests -- -Dclippy::all -Dclippy::pedantic` — no new warnings
- [ ] Runtime test under emcc + node (not in this PR; would require emcc in CI)
- [ ] Real-world test in a wasm-bindgen consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)



</p>
</details> 